### PR TITLE
Enable `native-tls` by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ license = "MIT OR Apache-2.0"
 [package.metadata.docs.rs]
 all-features = true
 
+[features]
+default = ["native-tls"]
+
 [dependencies]
 failure = "0.1"
 input_buffer = "0.2"

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 * Added support for publisher confirms
 * Added `ConnectionOptions::information` for specifying the informational string amiquip reports to the server upon connection
+* Made `native-tls` a default feature.
+* Reworked the `Connection::open*` family of methods into `Connection::open*` which require TLS, and `Connection::insecure_open*` which allow unencrypted connections.
 
 # Version 0.1.1 (2019-03-31)
 

--- a/README.md
+++ b/README.md
@@ -19,15 +19,23 @@ amiquip = "0.1"
 For usage, see the [documentation](https://docs.rs/amiquip/) and
 [examples](https://github.com/jgallagher/amiquip/tree/master/examples).
 
-## Feature `native-tls`
+## TLS Support
 
-By default, amiquip cannot use a TLS connection. To enable TLS connections, use
-the `native-tls` feature:
+By default, amiquip enables TLS support via the
+[native-tls](https://crates.io/crates/native-tls) crate. You can disable
+support for TLS by turning off default features:
 
 ```toml
 [dependencies]
-amiquip = { version = "0.1", features = ["native_tls"] }
+amiquip = { version = "0.1", default-features = false }
 ```
+
+If you disable TLS support, the methods `Connection::open`,
+`Connection::open_tuned`, and `Connection::open_tls_stream` will no longer be
+available, as all three only allow secure connections. The methods
+`Connection::insecure_open`, `Connection::insecure_open_tuned`, and
+`Connection::insecure_open_stream` will still be available; these methods
+support unencrypted connections.
 
 # License
 

--- a/examples/hello_world_consume.rs
+++ b/examples/hello_world_consume.rs
@@ -6,7 +6,7 @@ fn main() -> Result<()> {
     env_logger::init();
 
     // Open connection.
-    let mut connection = Connection::open("amqp://guest:guest@localhost:5672")?;
+    let mut connection = Connection::insecure_open("amqp://guest:guest@localhost:5672")?;
 
     // Open a channel - None says let the library choose the channel ID.
     let channel = connection.open_channel(None)?;

--- a/examples/hello_world_publish.rs
+++ b/examples/hello_world_publish.rs
@@ -6,7 +6,7 @@ fn main() -> Result<()> {
     env_logger::init();
 
     // Open connection.
-    let mut connection = Connection::open("amqp://guest:guest@localhost:5672")?;
+    let mut connection = Connection::insecure_open("amqp://guest:guest@localhost:5672")?;
 
     // Open a channel - None says let the library choose the channel ID.
     let channel = connection.open_channel(None)?;

--- a/examples/publisher_confirms.rs
+++ b/examples/publisher_confirms.rs
@@ -75,7 +75,7 @@ fn use_connection(connection: &mut Connection) -> Result<()> {
 }
 
 fn main() -> Result<()> {
-    let mut connection = Connection::open("amqp://guest:guest@localhost:5672")?;
+    let mut connection = Connection::insecure_open("amqp://guest:guest@localhost:5672")?;
 
     let result = use_connection(&mut connection);
 

--- a/examples/pubsub_emit_log.rs
+++ b/examples/pubsub_emit_log.rs
@@ -7,7 +7,7 @@ fn main() -> Result<()> {
     env_logger::init();
 
     // Open connection.
-    let mut connection = Connection::open("amqp://guest:guest@localhost:5672")?;
+    let mut connection = Connection::insecure_open("amqp://guest:guest@localhost:5672")?;
 
     // Open a channel - None says let the library choose the channel ID.
     let channel = connection.open_channel(None)?;

--- a/examples/pubsub_receive_logs.rs
+++ b/examples/pubsub_receive_logs.rs
@@ -9,7 +9,7 @@ fn main() -> Result<()> {
     env_logger::init();
 
     // Open connection.
-    let mut connection = Connection::open("amqp://guest:guest@localhost:5672")?;
+    let mut connection = Connection::insecure_open("amqp://guest:guest@localhost:5672")?;
 
     // Open a channel - None says let the library choose the channel ID.
     let channel = connection.open_channel(None)?;

--- a/examples/routing_emit_log_direct.rs
+++ b/examples/routing_emit_log_direct.rs
@@ -7,7 +7,7 @@ fn main() -> Result<()> {
     env_logger::init();
 
     // Open connection.
-    let mut connection = Connection::open("amqp://guest:guest@localhost:5672")?;
+    let mut connection = Connection::insecure_open("amqp://guest:guest@localhost:5672")?;
 
     // Open a channel - None says let the library choose the channel ID.
     let channel = connection.open_channel(None)?;

--- a/examples/routing_receive_logs_direct.rs
+++ b/examples/routing_receive_logs_direct.rs
@@ -9,7 +9,7 @@ fn main() -> Result<()> {
     env_logger::init();
 
     // Open connection.
-    let mut connection = Connection::open("amqp://guest:guest@localhost:5672")?;
+    let mut connection = Connection::insecure_open("amqp://guest:guest@localhost:5672")?;
 
     // Open a channel - None says let the library choose the channel ID.
     let channel = connection.open_channel(None)?;

--- a/examples/rpc_client.rs
+++ b/examples/rpc_client.rs
@@ -65,7 +65,7 @@ impl<'a> FibonacciRpcClient<'a> {
 
 fn main() -> Result<()> {
     // Open connection.
-    let mut connection = Connection::open("amqp://guest:guest@localhost:5672")?;
+    let mut connection = Connection::insecure_open("amqp://guest:guest@localhost:5672")?;
 
     // Open a channel - None says let the library choose the channel ID.
     let channel = connection.open_channel(None)?;

--- a/examples/rpc_server.rs
+++ b/examples/rpc_server.rs
@@ -17,7 +17,7 @@ fn main() -> Result<()> {
     env_logger::init();
 
     // Open connection.
-    let mut connection = Connection::open("amqp://guest:guest@localhost:5672")?;
+    let mut connection = Connection::insecure_open("amqp://guest:guest@localhost:5672")?;
 
     // Open a channel - None says let the library choose the channel ID.
     let channel = connection.open_channel(None)?;

--- a/examples/topics_emit_log.rs
+++ b/examples/topics_emit_log.rs
@@ -7,7 +7,7 @@ fn main() -> Result<()> {
     env_logger::init();
 
     // Open connection.
-    let mut connection = Connection::open("amqp://guest:guest@localhost:5672")?;
+    let mut connection = Connection::insecure_open("amqp://guest:guest@localhost:5672")?;
 
     // Open a channel - None says let the library choose the channel ID.
     let channel = connection.open_channel(None)?;

--- a/examples/topics_receive_logs.rs
+++ b/examples/topics_receive_logs.rs
@@ -9,7 +9,7 @@ fn main() -> Result<()> {
     env_logger::init();
 
     // Open connection.
-    let mut connection = Connection::open("amqp://guest:guest@localhost:5672")?;
+    let mut connection = Connection::insecure_open("amqp://guest:guest@localhost:5672")?;
 
     // Open a channel - None says let the library choose the channel ID.
     let channel = connection.open_channel(None)?;

--- a/examples/work_queues_new_task.rs
+++ b/examples/work_queues_new_task.rs
@@ -9,7 +9,7 @@ fn main() -> Result<()> {
     env_logger::init();
 
     // Open connection.
-    let mut connection = Connection::open("amqp://guest:guest@localhost:5672")?;
+    let mut connection = Connection::insecure_open("amqp://guest:guest@localhost:5672")?;
 
     // Open a channel - None says let the library choose the channel ID.
     let channel = connection.open_channel(None)?;

--- a/examples/work_queues_worker.rs
+++ b/examples/work_queues_worker.rs
@@ -11,7 +11,7 @@ fn main() -> Result<()> {
     env_logger::init();
 
     // Open connection.
-    let mut connection = Connection::open("amqp://guest:guest@localhost:5672")?;
+    let mut connection = Connection::insecure_open("amqp://guest:guest@localhost:5672")?;
 
     // Open a channel - None says let the library choose the channel ID.
     let channel = connection.open_channel(None)?;

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -202,10 +202,10 @@ impl Connection {
     /// * `auth_mechanism` (partial); the only allowed value is `external`, and if this query
     /// parameter is given any username or password on the URL will be ignored.
     ///
-    /// Using `amqps` URLs requires amiquip to be built with the `native-tls` feature. The
-    /// TLS-related RabbitMQ query parameters are not supported; use
+    /// Using `amqps` URLs requires amiquip to be built with the `native-tls` feature (which is
+    /// enabled by default). The TLS-related RabbitMQ query parameters are not supported; use
     /// [`open_tls_stream`](#method.open_tls_stream) with a configured `TlsConnector` if you need
-    /// control over the TLS parameters.
+    /// control over the TLS configuration.
     ///
     /// # Examples
     ///

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -162,10 +162,10 @@ impl Drop for Connection {
 }
 
 impl Connection {
-    /// Calls [`open_tuned`](#method.open_tuned) with default
+    /// Calls [`insecure_open_tuned`](#method.insecure_open_tuned) with default
     /// [`ConnectionTuning`](struct.ConnectionTuning.html) settings.
-    pub fn open(url: &str) -> Result<Connection> {
-        Self::open_tuned(url, ConnectionTuning::default())
+    pub fn insecure_open(url: &str) -> Result<Connection> {
+        Self::insecure_open_tuned(url, ConnectionTuning::default())
     }
 
     /// Open an AMQP connection from an `amqp://...` or `amqps://...` URL. Mostly follows the
@@ -207,7 +207,7 @@ impl Connection {
     /// # fn open_examples() -> Result<()> {
     /// // Empty amqp URL is equivalent to default options; handy for initial debugging and
     /// // development.
-    /// let conn1 = Connection::open("amqp://")?;
+    /// let conn1 = Connection::insecure_open("amqp://")?;
     /// let conn1 = Connection::insecure_open_stream(
     ///     tcp_stream("localhost:5672")?,
     ///     ConnectionOptions::<Auth>::default(),
@@ -216,7 +216,7 @@ impl Connection {
     ///
     /// // All possible options specified in the URL except auth_mechanism=external (which would
     /// // override the username and password).
-    /// let conn3 = Connection::open(
+    /// let conn3 = Connection::insecure_open(
     ///     "amqp://user:pass@example.com:12345/myvhost?heartbeat=30&channel_max=1024&connection_timeout=10000",
     /// )?;
     /// let conn3 = Connection::insecure_open_stream(
@@ -234,7 +234,7 @@ impl Connection {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn open_tuned(url: &str, tuning: ConnectionTuning) -> Result<Connection> {
+    pub fn insecure_open_tuned(url: &str, tuning: ConnectionTuning) -> Result<Connection> {
         self::amqp_url::open(url, tuning)
     }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -51,6 +51,11 @@ pub enum ErrorKind {
     #[fail(display = "invalid url: {}", _0)]
     InvalidUrl(Url),
 
+    /// An insecure URL was supplied to [`Connection::open`](struct.Connection.html#method.open),
+    /// which only allows `amqps://...` URLs.
+    #[fail(display = "insecure URL passed to method that only allows secure connections")]
+    InsecureUrl,
+
     /// The underlying socket was closed.
     #[fail(display = "underlying socket closed unexpectedly")]
     UnexpectedSocketClose,

--- a/src/io_loop/channel_handle.rs
+++ b/src/io_loop/channel_handle.rs
@@ -21,6 +21,7 @@ use std::fmt::Debug;
 // bytes.
 const FRAME_OVERHEAD: usize = 8;
 
+#[derive(Debug)]
 pub(crate) struct Channel0Handle {
     handle: IoLoopHandle0,
     frame_max: usize,

--- a/src/io_loop/io_loop_handle.rs
+++ b/src/io_loop/io_loop_handle.rs
@@ -11,13 +11,21 @@ use crossbeam_channel::Receiver as CrossbeamReceiver;
 use crossbeam_channel::Sender as CrossbeamSender;
 use log::error;
 use mio_extras::channel::SyncSender as MioSyncSender;
+use std::fmt;
 use std::ops::{Deref, DerefMut};
+use std::result::Result as StdResult;
 
 pub(super) struct IoLoopHandle {
     channel_id: u16,
     buf: OutputBuffer,
     tx: MioSyncSender<IoLoopMessage>,
     rx: CrossbeamReceiver<Result<ChannelMessage>>,
+}
+
+impl fmt::Debug for IoLoopHandle {
+    fn fmt(&self, f: &mut fmt::Formatter) -> StdResult<(), fmt::Error> {
+        write!(f, "IoLoopHandle {{ channel_id: {}, .. }}", self.channel_id)
+    }
 }
 
 impl IoLoopHandle {
@@ -168,6 +176,13 @@ pub(super) struct IoLoopHandle0 {
     alloc_chan_req_tx: MioSyncSender<Option<u16>>,
     alloc_chan_rep_rx: CrossbeamReceiver<Result<IoLoopHandle>>,
 }
+
+impl fmt::Debug for IoLoopHandle0 {
+    fn fmt(&self, f: &mut fmt::Formatter) -> StdResult<(), fmt::Error> {
+        write!(f, "IoLoopHandle0 {{ .. }}")
+    }
+}
+
 
 impl IoLoopHandle0 {
     pub(super) fn new(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,14 +6,19 @@
 //! Most errors, however, do result in effectively killing the channel or connection on which they
 //! occur.
 //!
-//! TLS support is optionally available via the [native-tls](https://crates.io/crates/native-tls)
-//! crate. To enable TLS support, turn on the `native-tls` feature of amiquip; e.g.,
+//! TLS support is enabled by default via the [native-tls](https://crates.io/crates/native-tls)
+//! crate. To enable disable TLS support at build time, disable amiquip's default features:
 //!
 //! ```toml
-//! # Cargo.toml
 //! [dependencies]
-//! amiquip = { version = "0.1", features = ["native-tls"] }
+//! amiquip = { version = "0.1", default-features = false }
 //! ```
+//!
+//! If you disable TLS support, the methods `Connection::open`, `Connection::open_tuned`, and
+//! `Connection::open_tls_stream` will no longer be available, as all three only allow secure
+//! connections. The methods `Connection::insecure_open`, `Connection::insecure_open_tuned`, and
+//! `Connection::insecure_open_stream` will still be available, as these methods support
+//! unencrypted connections.
 //!
 //! # Examples
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 //!
 //! fn main() -> Result<()> {
 //!     // Open connection.
-//!     let mut connection = Connection::open("amqp://guest:guest@localhost:5672")?;
+//!     let mut connection = Connection::insecure_open("amqp://guest:guest@localhost:5672")?;
 //!
 //!     // Open a channel - None says let the library choose the channel ID.
 //!     let channel = connection.open_channel(None)?;
@@ -48,7 +48,7 @@
 //!
 //! fn main() -> Result<()> {
 //!     // Open connection.
-//!     let mut connection = Connection::open("amqp://guest:guest@localhost:5672")?;
+//!     let mut connection = Connection::insecure_open("amqp://guest:guest@localhost:5672")?;
 //!
 //!     // Open a channel - None says let the library choose the channel ID.
 //!     let channel = connection.open_channel(None)?;


### PR DESCRIPTION
See Changelog notes for high-level overview of other changes.

Closes #3.