### PR TITLE
Modify socket registration during startup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amiquip"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["John Gallagher <johnkgallagher@gmail.com>"]
 edition = "2018"
 build = "build.rs"

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+# Version 0.2.2 (2019-05-07)
+
+* Modify how we register the mio socket to avoid getting spurious wakeups before
+  the socket is actually connected on Windows (hopefully fixes #8).
+
 # Version 0.2.1 (2019-04-09)
 
 * Fix bug when publishing a message with length 0 (or exactly equal to a


### PR DESCRIPTION
See #8 (and the linked mio issue) for discussion. Avoid registering for read events on the socket until we've successfully written to it (either via TLS handshake or sending the AMQP protocol header).

Closes #8.