### PR TITLE
Switch from failure to snafu

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ all-features = true
 default = ["native-tls"]
 
 [dependencies]
-failure = "0.1"
+snafu = "0.4"
 input_buffer = "0.2"
 bytes = "0.4"
 amq-protocol = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amiquip"
-version = "0.2.2"
+version = "0.3.0"
 authors = ["John Gallagher <johnkgallagher@gmail.com>"]
 edition = "2018"
 build = "build.rs"

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,4 @@
-# Version UPCOMING
+# Version 0.3 (2019-07-14)
 
 * Internally, `Error` is now created via `snafu` instead of `failure`. This leads to three breaking changes:
   * `Error` no longer implements `Clone` or `PartialEq`, but _does_ implement `std::error::Error`.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Version UPCOMING
 
+* Internally, `Error` is now created via `snafu` instead of `failure`. This leads to three breaking changes:
+  * `Error` no longer implements `Clone` or `PartialEq`, but _does_ implement `std::error::Error`.
+  * The `ErrorKind` helper enum no longer exists; `Error` is itself an enum.
+  * The definition of most error cases has changes (and there are considerably more of them).
 * Add missing `Debug`, `Clone`, `Copy`, and/or `Default` derivations for `ExchangeType`, `Publish`, and `QueueDeleteOption`.
 
 # Version 0.2.2 (2019-05-07)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-amiquip = "0.2"
+amiquip = "0.3"
 ```
 
 For usage, see the [documentation](https://docs.rs/amiquip/) and
@@ -27,7 +27,7 @@ support for TLS by turning off default features:
 
 ```toml
 [dependencies]
-amiquip = { version = "0.2", default-features = false }
+amiquip = { version = "0.3", default-features = false }
 ```
 
 If you disable TLS support, the methods `Connection::open`,

--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -1,4 +1,5 @@
-use crate::{Channel, Delivery, ErrorKind, FieldTable, Result};
+use crate::errors::*;
+use crate::{Channel, Delivery, FieldTable};
 use crossbeam_channel::Receiver;
 use std::cell::Cell;
 
@@ -30,7 +31,7 @@ pub struct ConsumerOptions {
 // Clippy warns about ConsumerMessage::Delivery being much larger than the other variants, but we
 // expect almost all instances of ConsumerMessage to be Deliveries.
 #[allow(clippy::large_enum_variant)]
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub enum ConsumerMessage {
     /// A delivered message.
     Delivery(Delivery),
@@ -47,13 +48,13 @@ pub enum ConsumerMessage {
     ClientClosedChannel,
 
     /// The server has closed the channel where this consumer was created.
-    ServerClosedChannel(ErrorKind),
+    ServerClosedChannel(Error),
 
     /// The client has closed the connection where this consumer was created.
     ClientClosedConnection,
 
     /// The server has closed the connection where this consumer was created.
-    ServerClosedConnection(ErrorKind),
+    ServerClosedConnection(Error),
 }
 
 /// A message consumer associated with an AMQP queue.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,203 +1,264 @@
-use failure::{Backtrace, Context, Fail};
-use std::sync::Arc;
-use std::{fmt, result};
-use url::ParseError as UrlParseError;
+use snafu::Snafu;
+//use std::sync::Arc;
+use std::{io, result};
 use url::Url;
 
 /// A type alias for handling errors throughout amiquip.
-pub type Result<T> = result::Result<T, Error>;
-
-/// An error that can occur from amiquip.
-#[derive(Clone, Debug)]
-pub struct Error {
-    ctx: Arc<Context<ErrorKind>>,
-}
-
-impl Error {
-    pub fn kind(&self) -> &ErrorKind {
-        self.ctx.get_context()
-    }
-}
-
-impl Fail for Error {
-    fn cause(&self) -> Option<&Fail> {
-        self.ctx.cause()
-    }
-
-    fn backtrace(&self) -> Option<&Backtrace> {
-        self.ctx.backtrace()
-    }
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.ctx.fmt(f)
-    }
-}
+pub type Result<T, E = Error> = result::Result<T, E>;
 
 /// Specific error cases returned by amiquip.
-#[derive(Clone, Debug, PartialEq, Fail)]
-pub enum ErrorKind {
+#[derive(Snafu, Debug)]
+#[snafu(visibility = "pub(crate)")]
+pub enum Error {
     /// URL parsing failed.
-    #[fail(display = "could not parse url: {}", _0)]
-    UrlParseError(UrlParseError),
+    #[snafu(display("could not parse url: {}", source))]
+    UrlParseError { source: url::ParseError },
 
     /// A TLS connection was requested (e.g., via URL), but the amiquip was built without TLS
     /// support.
-    #[fail(display = "amiquip built without TLS support")]
+    #[snafu(display("amiquip built without TLS support"))]
     TlsFeatureNotEnabled,
-
-    /// URL could not be decoded into an AMQP or AMQPS connection string.
-    #[fail(display = "invalid url: {}", _0)]
-    InvalidUrl(Url),
 
     /// An insecure URL was supplied to [`Connection::open`](struct.Connection.html#method.open),
     /// which only allows `amqps://...` URLs.
-    #[fail(display = "insecure URL passed to method that only allows secure connections")]
-    InsecureUrl,
+    #[snafu(display(
+        "insecure URL passed to method that only allows secure connections: {}",
+        url
+    ))]
+    InsecureUrl { url: Url },
 
     /// The underlying socket was closed.
-    #[fail(display = "underlying socket closed unexpectedly")]
+    #[snafu(display("underlying socket closed unexpectedly"))]
     UnexpectedSocketClose,
 
+    /// An I/O error occurred while reading from the socket.
+    #[snafu(display("I/O error while reading socket: {}", source))]
+    IoErrorReadingSocket { source: io::Error },
+
+    /// An I/O error occurred while writing from the socket.
+    #[snafu(display("I/O error while writing socket: {}", source))]
+    IoErrorWritingSocket { source: io::Error },
+
     /// We received data that could not be parsed as an AMQP frame.
-    #[fail(display = "received malformed data - expected AMQP frame")]
+    #[snafu(display("received malformed data - expected AMQP frame"))]
     MalformedFrame,
 
-    /// An I/O error occurred; the underlying cause will be an `io::Error`.
-    #[fail(display = "I/O error")]
-    Io,
+    /// Failed to resolve a URL into an IP address (or addresses).
+    #[snafu(display("URL did not resolve to an IP address: {}", url))]
+    UrlNoSocketAddrs { url: Url },
+
+    /// Error resolving a URL into an IP address (or addresses).
+    #[snafu(display("failed to resolve IP address of {}: {}", url, source))]
+    ResolveUrlToSocketAddr { url: Url, source: io::Error },
+
+    /// Failed to open TCP connection.
+    #[snafu(display("failed to connect to {}: {}", url, source))]
+    FailedToConnect { url: Url, source: io::Error },
+
+    /// Failed to set the port on a URL.
+    #[snafu(display("cannot specify port for URL {}", url))]
+    SpecifyUrlPort { url: Url },
+
+    /// Invalid scheme for URL.
+    #[snafu(display("invalid scheme for URL {}: expected `amqp` or `amqps`", url))]
+    InvalidUrlScheme { url: Url },
+
+    /// URL is missing domain.
+    #[snafu(display("invalid URL (missing domain): {}", url))]
+    UrlMissingDomain { url: Url },
+
+    /// URL contains extra path segments.
+    #[snafu(display("URL contains extraneous path segments: {}", url))]
+    ExtraUrlPathSegments { url: Url },
+
+    /// Could not parse heartbeat parameter of URL.
+    #[snafu(display("could not parse heartbeat parameter of URL {}: {}", url, source))]
+    UrlParseHeartbeat { url: Url, source: std::num::ParseIntError },
+
+    /// Could not parse channel_max parameter of URL.
+    #[snafu(display("could not parse channel_max parameter of URL {}: {}", url, source))]
+    UrlParseChannelMax { url: Url, source: std::num::ParseIntError },
+
+    /// Could not parse connection_timeout parameter of URL.
+    #[snafu(display("could not parse connection_timeout parameter of URL {}: {}", url, source))]
+    UrlParseConnectionTimeout { url: Url, source: std::num::ParseIntError },
+
+    /// Invalid auth mechanism requested in URL.
+    #[snafu(display("invalid auth mechanism for URL {}: {} (expected `external`)", url, mechanism))]
+    UrlInvalidAuthMechanism { url: Url, mechanism: String },
+
+    /// Unsupported URL parameter.
+    #[snafu(display("unsupported parameter in URL {}: {}", url, parameter))]
+    UrlUnsupportedParameter { url: Url, parameter: String },
+
+    /// Could not create mio Poll handle.
+    #[snafu(display("failed to create polling handle: {}", source))]
+    CreatePollHandle { source: io::Error },
+
+    /// Could not register descriptor with Poll handle.
+    #[snafu(display("failed to register object with polling handle: {}", source))]
+    RegisterWithPollHandle { source: io::Error },
+
+    /// Could not register descriptor with Poll handle.
+    #[snafu(display("failed to deregister object with polling handle: {}", source))]
+    DeregisterWithPollHandle { source: io::Error },
+
+    /// Failed to poll mio Poll handle.
+    #[snafu(display("failed to poll: {}", source))]
+    FailedToPoll { source: io::Error },
 
     /// The TLS handshake failed.
     #[cfg(feature = "native-tls")]
-    #[fail(display = "TLS handshake failed")]
-    TlsHandshake,
+    #[snafu(display("TLS handshake failed: {}", source))]
+    TlsHandshake { source: native_tls::Error },
 
     /// Error from underlying TLS implementation.
     #[cfg(feature = "native-tls")]
-    #[fail(display = "TLS error: {}", _0)]
-    TlsError(String),
+    #[snafu(display("could not create TLS connector: {}", source))]
+    CreateTlsConnector { source: native_tls::Error },
 
     /// The server does not support the requested auth mechanism.
-    #[fail(display = "requested auth mechanism unavailable (available = {})", _0)]
-    UnsupportedAuthMechanism(String),
+    #[snafu(display(
+        "requested auth mechanism unavailable (available = {}, requested = {})",
+        available,
+        requested
+    ))]
+    UnsupportedAuthMechanism {
+        available: String,
+        requested: String,
+    },
 
     /// The server does not support the requested locale.
-    #[fail(display = "requested locale unavailable (available = {})", _0)]
-    UnsupportedLocale(String),
+    #[snafu(display(
+        "requested locale unavailable (available = {}, requested = {})",
+        available,
+        requested
+    ))]
+    UnsupportedLocale {
+        available: String,
+        requested: String,
+    },
 
     /// The requested frame size is smaller than the minimum required by AMQP.
-    #[fail(display = "requested frame max is too small (min = {})", _0)]
-    FrameMaxTooSmall(u32),
+    #[snafu(display(
+        "requested frame max is too small (min = {}, requested = {})",
+        min,
+        requested
+    ))]
+    FrameMaxTooSmall { min: u32, requested: u32 },
 
     /// Timeout occurred while performing the initial TCP connection.
-    #[fail(display = "timeout occurred while waiting for TCP connection")]
+    #[snafu(display("timeout occurred while waiting for TCP connection"))]
     ConnectionTimeout,
 
     /// The server requested a Secure/Secure-Ok exchange, which are currently unsupported.
-    #[fail(display = "SASL secure/secure-ok exchanges are not supported")]
+    #[snafu(display("SASL secure/secure-ok exchanges are not supported"))]
     SaslSecureNotSupported,
 
     /// The supplied authentication credentials were not accepted by the server.
-    #[fail(display = "invalid credentials")]
+    #[snafu(display("invalid credentials"))]
     InvalidCredentials,
 
     /// The server missed too many successive heartbeats.
-    #[fail(display = "missed heartbeats from server")]
+    #[snafu(display("missed heartbeats from server"))]
     MissedServerHeartbeats,
 
     /// The server closed the connection with the given reply code and text.
-    #[fail(display = "server closed connection (code={} message={})", _0, _1)]
-    ServerClosedConnection(u16, String),
+    #[snafu(display("server closed connection (code={} message={})", code, message))]
+    ServerClosedConnection { code: u16, message: String },
 
     /// The client closed the connection.
-    #[fail(display = "client closed connection")]
+    #[snafu(display("client closed connection"))]
     ClientClosedConnection,
 
     /// The server closed the given channel with the given reply code and text.
-    #[fail(display = "server closed channel {} (code={}, message={})", _0, _1, _2)]
-    ServerClosedChannel(u16, u16, String),
+    #[snafu(display(
+        "server closed channel {} (code={}, message={})",
+        channel_id,
+        code,
+        message
+    ))]
+    ServerClosedChannel {
+        channel_id: u16,
+        code: u16,
+        message: String,
+    },
 
     /// The client closed the channel.
-    #[fail(display = "channel has been closed")]
+    #[snafu(display("channel has been closed"))]
     ClientClosedChannel,
 
     /// The I/O loop attempted to send a message to a caller that did not exist. This
     /// indicates either a bug in amiquip or a connection that is in a bad state and in the process
     /// of tearing down.
-    #[fail(display = "i/o loop thread tried to communicate with a nonexistent client")]
+    #[snafu(display("i/o loop thread tried to communicate with a nonexistent client"))]
     EventLoopClientDropped,
 
     /// The I/O loop has dropped the sending side of a channel, typically because it has exited due
     /// to another error.
-    #[fail(display = "i/o loop dropped sending side of a channel")]
+    #[snafu(display("i/o loop dropped sending side of a channel"))]
     EventLoopDropped,
 
     /// We received a valid AMQP frame but not one we expected; e.g., receiving an incorrect
     /// response to an AMQP method call.
-    #[fail(display = "AMQP protocol error - received unexpected frame")]
+    #[snafu(display("AMQP protocol error - received unexpected frame"))]
     FrameUnexpected,
 
     /// Forking the I/O thread failed.
-    #[fail(display = "fork failed")]
-    ForkFailed,
+    #[snafu(display("fork failed: {}", source))]
+    ForkFailed { source: io::Error },
 
     /// No more channels can be opened because there are already
     /// [`channel_max`](struct.ConnectionOptions.html#method.channel_max) channels open.
-    #[fail(display = "no more channel ids are available")]
+    #[snafu(display("no more channel ids are available"))]
     ExhaustedChannelIds,
 
     /// An explicit channel ID was requested, but that channel is unavailable for use (e.g.,
     /// because there is another open channel with the same ID).
-    #[fail(display = "requested channel id {} is unavailable", _0)]
-    UnavailableChannelId(u16),
+    #[snafu(display("requested channel id ({}) is unavailable", channel_id))]
+    UnavailableChannelId { channel_id: u16 },
 
     /// The client sent an AMQP exception to the server and closed the connection.
-    #[fail(display = "internal client exception - received unhandled frames from server")]
+    #[snafu(display("internal client exception - received unhandled frames from server"))]
     ClientException,
 
     /// The server sent frames for a channel ID we don't know about.
-    #[fail(display = "received message for nonexistent channel {}", _0)]
-    ReceivedFrameWithBogusChannelId(u16),
+    #[snafu(display("received message for nonexistent channel {}", channel_id))]
+    ReceivedFrameWithBogusChannelId { channel_id: u16 },
 
     /// The I/O thread panicked.
-    #[fail(display = "I/O thread panicked")]
+    #[snafu(display("I/O thread panicked"))]
     IoThreadPanic,
 
     /// The server sent us a consumer tag that is equal to another consumer tag we already have on
     /// the same channel.
-    #[fail(
-        display = "server sent duplicate consumer tag for channel {}: {}",
-        _0, _1
-    )]
-    DuplicateConsumerTag(u16, String),
+    #[snafu(display(
+        "server sent duplicate consumer tag for channel {}: {}",
+        channel_id,
+        consumer_tag
+    ))]
+    DuplicateConsumerTag { channel_id: u16, consumer_tag: String },
 
     /// The server sent us a [`Delivery`](struct.Delivery.html) for a channel we don't know about.
-    #[fail(
-        display = "received delivery with unknown consumer tag for channel {}: {}",
-        _0, _1
-    )]
-    UnknownConsumerTag(u16, String),
+    #[snafu(display(
+        "received delivery with unknown consumer tag for channel {}: {}",
+        channel_id,
+        consumer_tag
+    ))]
+    UnknownConsumerTag { channel_id: u16, consumer_tag: String },
 
     #[doc(hidden)]
-    #[fail(display = "invalid error case")]
+    #[snafu(display("invalid error case"))]
     __Nonexhaustive,
 }
 
-impl From<UrlParseError> for Error {
-    fn from(err: UrlParseError) -> Error {
-        Error::from(ErrorKind::UrlParseError(err))
-    }
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-impl From<ErrorKind> for Error {
-    fn from(kind: ErrorKind) -> Error {
-        Error::from(Context::new(kind))
-    }
-}
-
-impl From<Context<ErrorKind>> for Error {
-    fn from(ctx: Context<ErrorKind>) -> Error {
-        Error { ctx: Arc::new(ctx) }
+    #[test]
+    fn our_error_impls_std_error() {
+        fn is_err<T: std::error::Error>() {}
+        is_err::<Error>();
     }
 }

--- a/src/io_loop/content_collector.rs
+++ b/src/io_loop/content_collector.rs
@@ -1,4 +1,5 @@
-use crate::{AmqpProperties, Delivery, ErrorKind, Get, Result, Return};
+use crate::errors::*;
+use crate::{AmqpProperties, Delivery, Get, Return};
 use amq_protocol::frame::AMQPContentHeader;
 use amq_protocol::protocol::basic::Deliver;
 use amq_protocol::protocol::basic::GetOk as AmqpGetOk;
@@ -29,7 +30,7 @@ impl ContentCollector {
                 self.kind = Some(Kind::Delivery(State::Start(deliver)));
                 Ok(())
             }
-            Some(_) => Err(ErrorKind::FrameUnexpected)?,
+            Some(_) => FrameUnexpected.fail(),
         }
     }
 
@@ -39,7 +40,7 @@ impl ContentCollector {
                 self.kind = Some(Kind::Return(State::Start(return_)));
                 Ok(())
             }
-            Some(_) => Err(ErrorKind::FrameUnexpected)?,
+            Some(_) => FrameUnexpected.fail(),
         }
     }
 
@@ -49,7 +50,7 @@ impl ContentCollector {
                 self.kind = Some(Kind::Get(State::Start(get_ok)));
                 Ok(())
             }
-            Some(_) => Err(ErrorKind::FrameUnexpected)?,
+            Some(_) => FrameUnexpected.fail(),
         }
     }
 
@@ -88,7 +89,7 @@ impl ContentCollector {
                     Ok(None)
                 }
             },
-            None => Err(ErrorKind::FrameUnexpected)?,
+            None => FrameUnexpected.fail(),
         }
     }
 
@@ -124,7 +125,7 @@ impl ContentCollector {
                     Ok(None)
                 }
             },
-            None => Err(ErrorKind::FrameUnexpected)?,
+            None => FrameUnexpected.fail(),
         }
     }
 }
@@ -223,7 +224,7 @@ impl<T: ContentType> State<T> {
                     Ok(Content::NeedMore(State::Body(start, header, buf)))
                 }
             }
-            State::Body(_, _, _) => Err(ErrorKind::FrameUnexpected)?,
+            State::Body(_, _, _) => FrameUnexpected.fail(),
         }
     }
 
@@ -242,10 +243,10 @@ impl<T: ContentType> State<T> {
                 } else if buf.len() < body_size {
                     Ok(Content::NeedMore(State::Body(start, header, buf)))
                 } else {
-                    Err(ErrorKind::FrameUnexpected)?
+                    FrameUnexpected.fail()
                 }
             }
-            State::Start(_) => Err(ErrorKind::FrameUnexpected)?,
+            State::Start(_) => FrameUnexpected.fail(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! amiquip supports most features of the AMQP spec and some RabbitMQ extensions (see a list of
 //! [currently unsupported features](#unsupported-features) below). It aims to be robust: problems
-//! on a channel or connection should lead to a relevant [error](enum.ErrorKind.html) being raised.
+//! on a channel or connection should lead to a relevant [error](enum.Error.html) being raised.
 //! Most errors, however, do result in effectively killing the channel or connection on which they
 //! occur.
 //!
@@ -11,7 +11,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! amiquip = { version = "0.2", default-features = false }
+//! amiquip = { version = "0.3", default-features = false }
 //! ```
 //!
 //! If you disable TLS support, the methods `Connection::open`, `Connection::open_tuned`, and
@@ -194,7 +194,7 @@ pub use connection::{Connection, ConnectionBlockedNotification, ConnectionTuning
 pub use connection_options::ConnectionOptions;
 pub use consumer::{Consumer, ConsumerMessage, ConsumerOptions};
 pub use delivery::Delivery;
-pub use errors::{Error, ErrorKind, Result};
+pub use errors::{Error, Result};
 pub use exchange::{Exchange, ExchangeDeclareOptions, ExchangeType, Publish};
 pub use get::Get;
 pub use queue::{Queue, QueueDeclareOptions, QueueDeleteOptions};

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -1,4 +1,4 @@
-use crate::{ErrorKind, Result};
+use crate::errors::*;
 use amq_protocol::frame::generation::{
     gen_content_body_frame, gen_content_header_frame, gen_heartbeat_frame, gen_method_frame,
 };
@@ -25,7 +25,7 @@ macro_rules! impl_try_from_class {
             fn try_from(class: AMQPClass) -> Result<Self> {
                 match class {
                     $class($method(val)) => Ok(val),
-                    _ => Err(ErrorKind::FrameUnexpected)?,
+                    _ => FrameUnexpected.fail(),
                 }
             }
         }
@@ -159,10 +159,10 @@ impl<T: TryFromAmqpClass> TryFromAmqpFrame for T {
                 if expected_id == channel_id {
                     Self::try_from(method)
                 } else {
-                    Err(ErrorKind::FrameUnexpected)?
+                    FrameUnexpected.fail()
                 }
             }
-            _ => Err(ErrorKind::FrameUnexpected)?,
+            _ => FrameUnexpected.fail()
         }
     }
 }


### PR DESCRIPTION
Adds several new error cases, but breaks the definition of almost all of them. `Error` now implements `std::error::Error`, but no longer implements `Clone` or `PartialEq`, so this requires a bump to 0.3.0.

Closes #10.