### PR TITLE
Add documentation examples for arguments FieldTables.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+# Version 0.3.3 (2020-01-07)
+
+* Add documentation examples of using the `arguments` fields of
+  `QueueDeclareOptions` and `ConsumerOptions`.
+
 # Version 0.3.2 (2019-08-23)
 
 * Restore `#[doc(hidden)]` attribute with upgrade to snafu 0.4.4.

--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -7,6 +7,21 @@ use std::cell::Cell;
 ///
 /// The [`default`](#impl-Default) implementation sets all boolean fields to false and has an empty
 /// set of arguments.
+/// 
+/// # Example
+/// 
+/// The [`arguments`](#structfield.arguments) field can be used to set a
+/// [consumer priority](https://www.rabbitmq.com/consumer-priority.html):
+/// 
+/// ```rust
+/// # use amiquip::{AmqpValue, ConsumerOptions, FieldTable};
+/// let mut arguments = FieldTable::new();
+/// arguments.insert("x-priority".to_string(), AmqpValue::ShortInt(10));
+/// let options = ConsumerOptions {
+///     arguments,
+///     ..ConsumerOptions::default()
+/// };
+/// ```
 #[derive(Clone, Debug, Default)]
 pub struct ConsumerOptions {
     /// If true, the server will not send this consumer messages that were published by the

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -5,6 +5,24 @@ use amq_protocol::protocol::queue::{Declare, Delete};
 ///
 /// The [`default`](#impl-Default) implementation sets all boolean fields to false and has an empty
 /// set of arguments.
+/// 
+/// # Example
+/// 
+/// The [`arguments`](#structfield.arguments) field can be used to declare a
+/// [quorum queue](https://www.rabbitmq.com/quorum-queues.html):
+/// 
+/// ```rust
+/// # use amiquip::{AmqpValue, QueueDeclareOptions, FieldTable};
+/// let mut arguments = FieldTable::new();
+/// arguments.insert(
+///     "x-queue-type".to_string(),
+///     AmqpValue::LongString("quorum".to_string()),
+/// );
+/// let options = QueueDeclareOptions {
+///     arguments,
+///     ..QueueDeclareOptions::default()
+/// };
+/// ```
 #[derive(Clone, Debug, Default)]
 pub struct QueueDeclareOptions {
     /// If true, declares queue as durable (survives server restarts); if false, declares queue as


### PR DESCRIPTION
Add examples of setting consumer priorities and declaring quorum queues, both of which require using the relatively vague `arguments` FieldTables of their respective options structs.

Closes #17.