### PR TITLE
Clippy: Fix basic lints

### DIFF
--- a/examples/hello_world_publish.rs
+++ b/examples/hello_world_publish.rs
@@ -15,7 +15,7 @@ fn main() -> Result<()> {
     let exchange = Exchange::direct(&channel);
 
     // Publish a message to the "hello" queue.
-    exchange.publish(Publish::new("hello there".as_bytes(), "hello"))?;
+    exchange.publish(Publish::new(b"hello there", "hello"))?;
 
     connection.close()
 }

--- a/examples/work_queues_new_task.rs
+++ b/examples/work_queues_new_task.rs
@@ -3,7 +3,7 @@
 use amiquip::{AmqpProperties, Connection, Exchange, Publish, QueueDeclareOptions, Result};
 use std::env;
 
-const TASK_QUEUE: &'static str = "task_queue";
+const TASK_QUEUE: &str = "task_queue";
 
 fn main() -> Result<()> {
     env_logger::init();

--- a/examples/work_queues_worker.rs
+++ b/examples/work_queues_worker.rs
@@ -5,7 +5,7 @@ use amiquip::{Connection, ConsumerMessage, ConsumerOptions, QueueDeclareOptions,
 use std::thread;
 use std::time::Duration;
 
-const TASK_QUEUE: &'static str = "task_queue";
+const TASK_QUEUE: &str = "task_queue";
 
 fn main() -> Result<()> {
     env_logger::init();
@@ -40,6 +40,7 @@ fn main() -> Result<()> {
 
                 // Sleep for n seconds, where n is the number of '.' chars in the body,
                 // before we ack the message.
+                #[allow(clippy::clippy::naive_bytecount)]
                 let dits = delivery.body.iter().filter(|&&b| b == b'.').count();
                 thread::sleep(Duration::from_secs(dits as u64));
                 println!("({:>3}) ... done sleeping", i);

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -432,7 +432,7 @@ mod amqp_url {
                 if allow_insecure {
                     open_amqp(url, options, tuning)
                 } else {
-                    return InsecureUrl { url }.fail();
+                    InsecureUrl { url }.fail()
                 }
             }
             Scheme::Amqps => open_amqps(url, options, tuning),
@@ -457,7 +457,7 @@ mod amqp_url {
             match result {
                 Ok(connection) => return Ok(connection),
                 Err(err) => {
-                    last_err = Some(err.into());
+                    last_err = Some(err);
                 }
             }
         }

--- a/src/connection_options.rs
+++ b/src/connection_options.rs
@@ -135,14 +135,14 @@ impl<Auth: Sasl> ConnectionOptions<Auth> {
         let mechanism = self.auth.mechanism();
         if !server_supports(&start.mechanisms, &mechanism) {
             return UnsupportedAuthMechanism {
-                available: start.mechanisms.clone(),
+                available: start.mechanisms,
                 requested: mechanism,
             }
             .fail();
         }
         if !server_supports(&start.locales, &self.locale) {
             return UnsupportedLocale {
-                available: start.locales.clone(),
+                available: start.locales,
                 requested: self.locale.clone(),
             }
             .fail();
@@ -308,7 +308,7 @@ mod tests {
             version_major: 0,
             version_minor: 9,
             server_properties: FieldTable::new(),
-            mechanisms: options.auth.mechanism().clone(),
+            mechanisms: options.auth.mechanism(),
             locales: server_locales.to_string(),
         };
 

--- a/src/frame_buffer.rs
+++ b/src/frame_buffer.rs
@@ -196,7 +196,10 @@ mod tests {
 
         let mut got = Vec::new();
         let mut buf = make_buffer();
-        let n = buf.read_from(&mut c, |f| Ok(got.push(f))).unwrap();
+        let n = buf.read_from(&mut c, |f| {
+            got.push(f);
+            Ok(())
+        }).unwrap();
 
         assert_eq!(n, 8);
         assert_eq!(got, vec![Vec::from(&frame0[..]), Vec::from(&frame1[..])]);
@@ -227,7 +230,7 @@ mod tests {
             })
             .unwrap();
         assert_eq!(n, 2);
-        assert_eq!(got, Some(Vec::from("a\x04aa".as_bytes())));
+        assert_eq!(got, Some(b"a\x04aa".to_vec()));
     }
 
     #[test]
@@ -241,21 +244,30 @@ mod tests {
 
         let mut got = Vec::new();
         let mut buf = make_buffer();
-        let n = buf.read_from(&mut c, |f| Ok(got.push(f))).unwrap();
+        let n = buf.read_from(&mut c, |f| {
+            got.push(f);
+            Ok(())
+        }).unwrap();
         assert_eq!(n, 2);
         assert!(got.is_empty());
 
-        let n = buf.read_from(&mut c, |f| Ok(got.push(f))).unwrap();
+        let n = buf.read_from(&mut c, |f| {
+            got.push(f);
+            Ok(())
+        }).unwrap();
         assert_eq!(n, 5);
-        assert_eq!(got, vec![Vec::from("a\x04aa".as_bytes())]);
+        assert_eq!(got, vec![b"a\x04aa".to_vec()]);
 
-        let n = buf.read_from(&mut c, |f| Ok(got.push(f))).unwrap();
+        let n = buf.read_from(&mut c, |f| {
+            got.push(f);
+            Ok(())
+        }).unwrap();
         assert_eq!(n, 3);
         assert_eq!(
             got,
             vec![
-                Vec::from("a\x04aa".as_bytes()),
-                Vec::from("b\x04bb".as_bytes())
+                b"a\x04aa".to_vec(),
+                b"b\x04bb".to_vec()
             ]
         );
     }

--- a/src/io_loop/channel_handle.rs
+++ b/src/io_loop/channel_handle.rs
@@ -174,7 +174,7 @@ impl ChannelHandle {
             self.handle.send_content_body(&content[..self.frame_max])?;
             content = &content[self.frame_max..];
         }
-        if content.len() > 0 {
+        if !content.is_empty() {
             trace!(
                 "sending final content body frame on channel {} (len = {})",
                 self.channel_id(),

--- a/src/io_loop/channel_slots.rs
+++ b/src/io_loop/channel_slots.rs
@@ -126,7 +126,7 @@ mod tests {
     #[should_panic]
     fn set_channel_max_after_insert_panics() {
         let mut cs = with_channel_max(4);
-        if let Err(_) = cs.insert(Some(1), id) {
+        if cs.insert(Some(1), id).is_err() {
             return;
         }
         cs.set_channel_max(4);
@@ -136,10 +136,10 @@ mod tests {
     #[should_panic]
     fn set_channel_max_after_insert_and_remove_panics() {
         let mut cs = with_channel_max(4);
-        if let Err(_) = cs.insert(Some(1), id) {
+        if cs.insert(Some(1), id).is_err() {
             return;
         }
-        if let None = cs.remove(1) {
+        if cs.remove(1).is_none() {
             return;
         }
         cs.set_channel_max(4);

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -212,7 +212,7 @@ pub(crate) struct OutputBuffer(Vec<u8>);
 
 impl OutputBuffer {
     pub fn with_protocol_header() -> OutputBuffer {
-        OutputBuffer(Vec::from("AMQP\x00\x00\x09\x01".as_bytes()))
+        OutputBuffer(b"AMQP\x00\x00\x09\x01".to_vec())
     }
 
     pub(crate) fn empty() -> OutputBuffer {


### PR DESCRIPTION
Every time I work on Rust project I'm automatically using Clippy for code analysis. So while I was working on https://github.com/jgallagher/amiquip/pull/26 I also fixed basic Clippy lints.

If you like it, I can also look on pedantic lints.