### PR TITLE
Dependency hygiene for rustc 1.72.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amiquip"
-version = "0.4.2"
+version = "0.5.0"
 authors = ["John Gallagher <johnkgallagher@gmail.com>"]
 edition = "2018"
 build = "build.rs"
@@ -21,11 +21,11 @@ default = ["native-tls"]
 snafu = { version = "0.7", default-features = false, features = ["std"]}
 input_buffer = "0.5"
 bytes = "1.1"
-amq-protocol = "1.4"
+amq-protocol = "7.1"
 log = "0.4"
 mio = "0.6"
 mio-extras = "2.0"
-cookie-factory = "0.2"
+cookie-factory = "0.3"
 crossbeam-channel = "0.5"
 indexmap = "1.6"
 url = "2.2.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "amiquip"
 version = "0.5.0"
 authors = ["John Gallagher <johnkgallagher@gmail.com>"]
-edition = "2018"
+edition = "2021"
 build = "build.rs"
 description = "Pure Rust RabbitMQ client"
 repository = "https://github.com/jgallagher/amiquip"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,22 +20,22 @@ default = ["native-tls"]
 [dependencies]
 snafu = { version = "0.7", default-features = false, features = ["std"]}
 input_buffer = "0.5"
-bytes = "1.1"
+bytes = "1.4"
 amq-protocol = "7.1"
 log = "0.4"
 mio = "0.6"
 mio-extras = "2.0"
 cookie-factory = "0.3"
 crossbeam-channel = "0.5"
-indexmap = "1.6"
-url = "2.2.2"
+indexmap = "2.0"
+url = "2.4.0"
 native-tls = { version = "0.2", optional = true }
-percent-encoding = "2.1"
+percent-encoding = "2.3"
 
 [build-dependencies]
-built = "0.5.1"
+built = "0.6.1"
 
 [dev-dependencies]
-uuid = { version = "0.8", features = [ "v4" ] }
-env_logger = "0.9"
+uuid = { version = "1.4", features = [ "v4" ] }
+env_logger = "0.10"
 mockstream = "0.0.3"

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
   * cookie-factory (now 0.3)
 * Deprecated `Channel::qos()` in favor of `Channel::set_qos()`
 * `Error::__Nonexhaustive` replaced with `non_exhaustive` attribute
+* Switch to 2021 Edition
 
 # Version 0.4.2 (2022-01-12)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 * Updated dependencies to address future incompatiblity lints.
   * amq-protocol (now 7.1)
   * cookie-factory (now 0.3)
+* Deprecated `Channel::qos()` in favor of `Channel::set_qos()`
 
 # Version 0.4.2 (2022-01-12)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
   * amq-protocol (now 7.1)
   * cookie-factory (now 0.3)
 * Deprecated `Channel::qos()` in favor of `Channel::set_qos()`
+* `Error::__Nonexhaustive` replaced with `non_exhaustive` attribute
 
 # Version 0.4.2 (2022-01-12)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+# Version 0.5.0 (2023-08-21)
+
+* Updated dependencies to address future incompatiblity lints.
+  * amq-protocol (now 7.1)
+  * cookie-factory (now 0.3)
+
 # Version 0.4.2 (2022-01-12)
 
 * Fix compilation error with default features disabled (#36)

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,14 @@
 * Deprecated `Channel::qos()` in favor of `Channel::set_qos()`
 * `Error::__Nonexhaustive` replaced with `non_exhaustive` attribute
 * Switch to 2021 Edition
+* Update several other dependencies:
+  * built (now 0.6.1)
+  * bytes (now 1.4)
+  * env_loger (now 0.10)
+  * indexmap (now 2.0)
+  * percent-encoding (now 2.3)
+  * url (now 2.4.0)
+  * uuid (now 1.4)
 
 # Version 0.4.2 (2022-01-12)
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-amiquip = "0.4"
+amiquip = "0.5"
 ```
 
 For usage, see the [documentation](https://docs.rs/amiquip/) and
@@ -20,7 +20,7 @@ For usage, see the [documentation](https://docs.rs/amiquip/) and
 
 ## Minimum Support Rust Version
 
-The minimum supported Rust version for amiquip 0.4.2 is currently Rust 1.46.0,
+The minimum supported Rust version for amiquip 0.5.0 is currently Rust 1.46.0,
 but that may change with a patch release (and could change with a patch release
 to a dependency without our knowledge).
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For usage, see the [documentation](https://docs.rs/amiquip/) and
 
 ## Minimum Support Rust Version
 
-The minimum supported Rust version for amiquip 0.5.0 is currently Rust 1.46.0,
+The minimum supported Rust version for amiquip 0.5.0 is currently Rust 1.56.0,
 but that may change with a patch release (and could change with a patch release
 to a dependency without our knowledge).
 

--- a/examples/pubsub_receive_logs.rs
+++ b/examples/pubsub_receive_logs.rs
@@ -32,7 +32,7 @@ fn main() -> Result<()> {
     println!("created exclusive queue {}", queue.name());
 
     // Bind our queue to the logs exchange.
-    queue.bind(&exchange, "", FieldTable::new())?;
+    queue.bind(&exchange, "", FieldTable::default())?;
 
     // Start a consumer. Use no_ack: true so the server doesn't wait for us to ack
     // the messages it sends us.

--- a/examples/routing_receive_logs_direct.rs
+++ b/examples/routing_receive_logs_direct.rs
@@ -43,7 +43,7 @@ fn main() -> Result<()> {
 
     for severity in args.skip(1) {
         // Bind to each requested log severity.
-        queue.bind(&exchange, severity, FieldTable::new())?;
+        queue.bind(&exchange, severity, FieldTable::default())?;
     }
 
     // Start a consumer. Use no_ack: true so the server doesn't wait for us to ack

--- a/examples/rpc_client.rs
+++ b/examples/rpc_client.rs
@@ -4,6 +4,7 @@ use amiquip::{
     AmqpProperties, Channel, Connection, Consumer, ConsumerMessage, ConsumerOptions, Exchange,
     Publish, Queue, QueueDeclareOptions, Result,
 };
+use amq_protocol::types::ShortString;
 use uuid::Uuid;
 
 struct FibonacciRpcClient<'a> {
@@ -36,12 +37,12 @@ impl<'a> FibonacciRpcClient<'a> {
     }
 
     fn call(&self, n: u64) -> Result<String> {
-        let correlation_id = format!("{}", Uuid::new_v4());
+        let correlation_id: ShortString = format!("{}", Uuid::new_v4()).into();
         self.exchange.publish(Publish::with_properties(
             format!("{}", n).as_bytes(),
             "rpc_queue",
             AmqpProperties::default()
-                .with_reply_to(self.queue.name().to_string())
+                .with_reply_to(self.queue.name().into())
                 .with_correlation_id(correlation_id.clone()),
         ))?;
         for message in self.consumer.receiver().iter() {

--- a/examples/rpc_server.rs
+++ b/examples/rpc_server.rs
@@ -57,7 +57,7 @@ fn main() -> Result<()> {
 
                 exchange.publish(Publish::with_properties(
                     response.as_bytes(),
-                    reply_to,
+                    reply_to.to_string(),
                     AmqpProperties::default().with_correlation_id(corr_id),
                 ))?;
                 consumer.ack(delivery)?;

--- a/examples/topics_receive_logs.rs
+++ b/examples/topics_receive_logs.rs
@@ -42,7 +42,7 @@ fn main() -> Result<()> {
     }
 
     for binding_key in args.skip(1) {
-        queue.bind(&exchange, binding_key, FieldTable::new())?;
+        queue.bind(&exchange, binding_key, FieldTable::default())?;
     }
 
     // Start a consumer. Use no_ack: true so the server doesn't wait for us to ack

--- a/examples/work_queues_worker.rs
+++ b/examples/work_queues_worker.rs
@@ -26,7 +26,7 @@ fn main() -> Result<()> {
     )?;
 
     // Set QOS to only send us 1 message at a time.
-    channel.qos(0, 1, false)?;
+    channel.set_qos(1, false)?;
 
     // Start a consumer.
     let consumer = queue.consume(ConsumerOptions::default())?;

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -274,7 +274,7 @@ impl Channel {
     ) -> Result<Queue> {
         let queue = queue.into();
         assert!(
-            queue != "",
+            !queue.is_empty(),
             "cannot asynchronously declare auto-named queues"
         );
         let declare = AmqpQueue::Declare(options.into_declare(queue.clone(), false, true));

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -290,7 +290,7 @@ impl Channel {
             durable: false,
             exclusive: false,
             auto_delete: false,
-            arguments: FieldTable::new(),
+            arguments: FieldTable::default(),
         };
         let declare = AmqpQueue::Declare(options.into_declare(queue.into(), true, false));
         let ok = self.call::<_, QueueDeclareOk>(declare)?;
@@ -522,7 +522,7 @@ impl Channel {
             durable: false,
             auto_delete: false,
             internal: false,
-            arguments: FieldTable::new(),
+            arguments: FieldTable::default(),
         };
         let declare =
             AmqpExchange::Declare(options.into_declare(type_, exchange.clone(), true, false));

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -165,7 +165,6 @@ impl Channel {
     pub fn basic_publish<S: Into<String>>(&self, exchange: S, publish: Publish) -> Result<()> {
         let mut inner = self.inner.borrow_mut();
         inner.call_nowait(AmqpBasic::Publish(AmqpPublish {
-            ticket: 0,
             exchange: exchange.into().into(), // S -> String -> ShortString
             routing_key: publish.routing_key.into(),
             mandatory: publish.mandatory,
@@ -314,7 +313,6 @@ impl Channel {
     /// to you on demand instead of polling with `get`.
     pub fn basic_get<S: Into<String>>(&self, queue: S, no_ack: bool) -> Result<Option<Get>> {
         self.inner.borrow_mut().get(AmqpGet {
-            ticket: 0,
             queue: queue.into().into(), // S -> String -> ShortString
             no_ack,
         })
@@ -334,7 +332,6 @@ impl Channel {
         // 2. The I/O loop allocates the channel to send deliveries when it
         //    receives consume-ok.
         let (tag, rx) = self.inner.borrow_mut().consume(Consume {
-            ticket: 0,
             queue: queue.into().into(), // S -> String -> ShortString
             consumer_tag: ShortString::default(),
             no_local: options.no_local,
@@ -360,7 +357,6 @@ impl Channel {
         arguments: FieldTable,
     ) -> Result<()> {
         let bind = AmqpQueue::Bind(QueueBind {
-            ticket: 0,
             queue: queue.into().into(),
             exchange: exchange.into().into(),
             routing_key: routing_key.into().into(),
@@ -384,7 +380,6 @@ impl Channel {
         arguments: FieldTable,
     ) -> Result<()> {
         let bind = AmqpQueue::Bind(QueueBind {
-            ticket: 0,
             queue: queue.into().into(),
             exchange: exchange.into().into(),
             routing_key: routing_key.into().into(),
@@ -408,7 +403,6 @@ impl Channel {
         arguments: FieldTable,
     ) -> Result<()> {
         let unbind = AmqpQueue::Unbind(QueueUnbind {
-            ticket: 0,
             queue: queue.into().into(),
             exchange: exchange.into().into(),
             routing_key: routing_key.into().into(),
@@ -425,7 +419,6 @@ impl Channel {
     /// [`Queue::purge`](struct.Queue.html#method.purge) to avoid this.
     pub fn queue_purge<S: Into<String>>(&self, queue: S) -> Result<u32> {
         let purge = AmqpQueue::Purge(QueuePurge {
-            ticket: 0,
             queue: queue.into().into(), // S -> String -> ShortString
             nowait: false,
         });
@@ -440,7 +433,6 @@ impl Channel {
     /// [`Queue::purge_nowait`](struct.Queue.html#method.purge_nowait) to avoid this.
     pub fn queue_purge_nowait<S: Into<String>>(&self, queue: S) -> Result<()> {
         let purge = AmqpQueue::Purge(QueuePurge {
-            ticket: 0,
             queue: queue.into().into(),
             nowait: true,
         });
@@ -548,7 +540,6 @@ impl Channel {
         arguments: FieldTable,
     ) -> Result<()> {
         let bind = AmqpExchange::Bind(ExchangeBind {
-            ticket: 0,
             destination: destination.into().into(),
             source: source.into().into(),
             routing_key: routing_key.into().into(),
@@ -576,7 +567,6 @@ impl Channel {
         arguments: FieldTable,
     ) -> Result<()> {
         let bind = AmqpExchange::Bind(ExchangeBind {
-            ticket: 0,
             destination: destination.into().into(),
             source: source.into().into(),
             routing_key: routing_key.into().into(),
@@ -604,7 +594,6 @@ impl Channel {
         arguments: FieldTable,
     ) -> Result<()> {
         let unbind = AmqpExchange::Unbind(ExchangeUnbind {
-            ticket: 0,
             destination: destination.into().into(),
             source: source.into().into(),
             routing_key: routing_key.into().into(),
@@ -634,7 +623,6 @@ impl Channel {
         arguments: FieldTable,
     ) -> Result<()> {
         let unbind = AmqpExchange::Unbind(ExchangeUnbind {
-            ticket: 0,
             destination: destination.into().into(),
             source: source.into().into(),
             routing_key: routing_key.into().into(),
@@ -652,7 +640,6 @@ impl Channel {
     /// `if_unused` was true and it has queue bindings), it will close this channel.
     pub fn exchange_delete<S: Into<String>>(&self, exchange: S, if_unused: bool) -> Result<()> {
         let delete = AmqpExchange::Delete(ExchangeDelete {
-            ticket: 0,
             exchange: exchange.into().into(),
             if_unused,
             nowait: false,
@@ -672,7 +659,6 @@ impl Channel {
         if_unused: bool,
     ) -> Result<()> {
         let delete = AmqpExchange::Delete(ExchangeDelete {
-            ticket: 0,
             exchange: exchange.into().into(),
             if_unused,
             nowait: true,

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -127,24 +127,28 @@ impl Channel {
 
     /// Specify the prefetching window.
     ///
-    /// If `prefetch_size` is greater than 0, instructs the server to go ahead and send messages up
-    /// to `prefetch_size` in bytes even before previous deliveries have been acknowledged. If
-    /// `prefetch_count` is greater than 0, instructs the server to go ahead and send up to
-    /// `prefetch_count` messages even before previous deliveries have been acknowledged. If either
-    /// field is 0, that field is ignored. If both are 0, prefetching is disabled. If both are
-    /// nonzero, messages will only be sent before previous deliveries are acknowledged if that
-    /// send would satisfy both prefetch limits. If a consumer is started with `no_ack` set to
-    /// true, prefetch limits are ignored and messages are sent as quickly as possible.
+    /// `prefetch_size` is no longer supported and will be ignored. Use `set_qos` instead.
+    #[deprecated(since = "0.5.0", note = "amq-protocol no longer exposes prefetch_size")]
+    pub fn qos(&self, prefetch_size: u32, prefetch_count: u16, global: bool) -> Result<()> {
+        let _ = prefetch_size;
+        self.set_qos(prefetch_count, global)
+    }
+
+    /// Specify the prefetching window.
     ///
-    /// According to the AMQP spec, setting `global` to true means to apply these prefetch settings
+    /// If `prefetch_count` is greater than 0, instructs the server to go ahead and send up to
+    /// `prefetch_count` messages even before previous deliveries have been acknowledged. If zero,
+    /// the field is ignored, and prefetching is disabled. If a consumer is started with `no_ack`
+    /// set to `true`, prefetch limits are ignored and messages are sent as quickly as possible.
+    ///
+    /// According to the AMQP spec, setting `global` to `true` means to apply these prefetch settings
     /// to all channels in the entire connection, and `global` false means the settings apply only
     /// to this channel. RabbitMQ does not interpret `global` the same way; for it, `global: true`
     /// means the settings apply to all consumers on this channel, and `global: false` means the
-    /// settings apply only to consumers created on this channel after this call to `qos`, not
+    /// settings apply only to consumers created on this channel after this call to `set_qos`, not
     /// affecting previously-created consumers.
-    pub fn qos(&self, prefetch_size: u32, prefetch_count: u16, global: bool) -> Result<()> {
+    pub fn set_qos(&self, prefetch_count: u16, global: bool) -> Result<()> {
         self.call::<_, QosOk>(AmqpBasic::Qos(Qos {
-            prefetch_size,
             prefetch_count,
             global,
         }))

--- a/src/confirm.rs
+++ b/src/confirm.rs
@@ -120,18 +120,18 @@ impl ConfirmSmoother {
     /// expected delivery tag and we had not previously seen the next tag), or multiple items (if
     /// `confirm` is a `multiple: true` confirmation or we've previously seen out-of-order tags
     /// that are next sequentially after `confirm`'s tag).
-    pub fn process<'a>(&'a mut self, confirm: Confirm) -> impl Iterator<Item = Confirm> + 'a {
+    pub fn process(&mut self, confirm: Confirm) -> impl Iterator<Item = Confirm> + '_ {
         match confirm {
             Confirm::Ack(inner) => self.new_iter(inner, Confirm::Ack),
             Confirm::Nack(inner) => self.new_iter(inner, Confirm::Nack),
         }
     }
 
-    fn new_iter<'a>(
-        &'a mut self,
+    fn new_iter(
+        &mut self,
         payload: ConfirmPayload,
         to_confirm: fn(ConfirmPayload) -> Confirm,
-    ) -> impl Iterator<Item = Confirm> + 'a {
+    ) -> impl Iterator<Item = Confirm> + '_ {
         Iter {
             parent: self,
             payload,

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -548,7 +548,7 @@ mod amqp_url {
             // "amqp://host/" should have a vhost of Some(""). But we can't tell
             // the difference between these two with the url lib, so we'll just toss
             // out the latter. We now have no way of specifying a vhost of "".
-            if vhost != "" {
+            if !vhost.is_empty() {
                 options = options.virtual_host(percent_decode(vhost));
             }
 

--- a/src/connection_options.rs
+++ b/src/connection_options.rs
@@ -211,9 +211,9 @@ impl<Auth: Sasl> ConnectionOptions<Auth> {
         let frame_max = u32::min(frame_max0, frame_max1);
         let heartbeat = u16::min(tune.heartbeat, self.heartbeat);
 
-        if frame_max < u32::from(FRAME_MIN_SIZE) {
+        if frame_max < FRAME_MIN_SIZE {
             return FrameMaxTooSmallSnafu {
-                min: u32::from(FRAME_MIN_SIZE),
+                min: FRAME_MIN_SIZE,
                 requested: frame_max,
             }
             .fail();

--- a/src/connection_options.rs
+++ b/src/connection_options.rs
@@ -229,8 +229,6 @@ impl<Auth: Sasl> ConnectionOptions<Auth> {
     pub(crate) fn make_open(&self) -> Open {
         Open {
             virtual_host: self.virtual_host.clone().into(),
-            capabilities: "".to_string(), // reserved
-            insist: false,                // reserved
         }
     }
 }

--- a/src/connection_options.rs
+++ b/src/connection_options.rs
@@ -151,7 +151,7 @@ impl<Auth: Sasl> ConnectionOptions<Auth> {
         // bundle up info about this crate as client properties
         let mut client_properties = FieldTable::new();
         let mut set_prop = |k: &str, v: String| {
-            client_properties.insert(k.to_string(), AMQPValue::LongString(v));
+            client_properties.insert(k.into(), AMQPValue::LongString(v));
         };
         set_prop("product", crate::built_info::PKG_NAME.to_string());
         set_prop("version", crate::built_info::PKG_VERSION.to_string());
@@ -168,21 +168,18 @@ impl<Auth: Sasl> ConnectionOptions<Auth> {
         }
         let mut capabilities = FieldTable::new();
         let mut set_cap = |k: &str| {
-            capabilities.insert(k.to_string(), AMQPValue::Boolean(true));
+            capabilities.insert(k.into(), AMQPValue::Boolean(true));
         };
         set_cap("consumer_cancel_notify");
         set_cap("connection.blocked");
-        client_properties.insert(
-            "capabilities".to_string(),
-            AMQPValue::FieldTable(capabilities),
-        );
+        client_properties.insert("capabilities".into(), AMQPValue::FieldTable(capabilities));
 
         Ok((
             StartOk {
                 client_properties,
-                mechanism,
+                mechanism: mechanism.into(),
                 response: self.auth.response(),
-                locale: self.locale.clone(),
+                locale: self.locale.clone().into(),
             },
             start.server_properties,
         ))
@@ -229,7 +226,7 @@ impl<Auth: Sasl> ConnectionOptions<Auth> {
 
     pub(crate) fn make_open(&self) -> Open {
         Open {
-            virtual_host: self.virtual_host.clone(),
+            virtual_host: self.virtual_host.clone().into(),
             capabilities: "".to_string(), // reserved
             insist: false,                // reserved
         }

--- a/src/connection_options.rs
+++ b/src/connection_options.rs
@@ -151,7 +151,7 @@ impl<Auth: Sasl> ConnectionOptions<Auth> {
         }
 
         // bundle up info about this crate as client properties
-        let mut client_properties = FieldTable::new();
+        let mut client_properties = FieldTable::default();
         let mut set_prop = |k: &str, v: String| {
             client_properties.insert(k.into(), AMQPValue::LongString(v.into()));
         };
@@ -168,7 +168,7 @@ impl<Auth: Sasl> ConnectionOptions<Auth> {
         if let Some(information) = &self.information {
             set_prop("information", information.to_string());
         }
-        let mut capabilities = FieldTable::new();
+        let mut capabilities = FieldTable::default();
         let mut set_cap = |k: &str| {
             capabilities.insert(k.into(), AMQPValue::Boolean(true));
         };
@@ -284,7 +284,7 @@ mod tests {
         let start = Start {
             version_major: 0,
             version_minor: 9,
-            server_properties: FieldTable::new(),
+            server_properties: FieldTable::default(),
             mechanisms: server_mechanisms.into(),
             locales: options.locale.clone().into(),
         };
@@ -306,7 +306,7 @@ mod tests {
         let start = Start {
             version_major: 0,
             version_minor: 9,
-            server_properties: FieldTable::new(),
+            server_properties: FieldTable::default(),
             mechanisms: options.auth.mechanism().into(),
             locales: server_locales.into(),
         };

--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -15,7 +15,7 @@ use std::cell::Cell;
 ///
 /// ```rust
 /// # use amiquip::{AmqpValue, ConsumerOptions, FieldTable};
-/// let mut arguments = FieldTable::new();
+/// let mut arguments = FieldTable::default();
 /// arguments.insert("x-priority".into(), AmqpValue::ShortInt(10));
 /// let options = ConsumerOptions {
 ///     arguments,

--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -164,7 +164,7 @@ impl Consumer<'_> {
             return Ok(());
         }
         self.cancelled.set(true);
-        self.channel.basic_cancel(&self)
+        self.channel.basic_cancel(self)
     }
 
     /// Calls [`Delivery::ack`](struct.Delivery.html#method.ack) on `delivery` using the channel

--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -16,7 +16,7 @@ use std::cell::Cell;
 /// ```rust
 /// # use amiquip::{AmqpValue, ConsumerOptions, FieldTable};
 /// let mut arguments = FieldTable::new();
-/// arguments.insert("x-priority".to_string(), AmqpValue::ShortInt(10));
+/// arguments.insert("x-priority".into(), AmqpValue::ShortInt(10));
 /// let options = ConsumerOptions {
 ///     arguments,
 ///     ..ConsumerOptions::default()

--- a/src/delivery.rs
+++ b/src/delivery.rs
@@ -32,13 +32,13 @@ impl Delivery {
         properties: AmqpProperties,
     ) -> (String, Delivery) {
         (
-            deliver.consumer_tag,
+            deliver.consumer_tag.as_str().to_owned(),
             Delivery {
                 channel_id,
                 delivery_tag: deliver.delivery_tag,
                 redelivered: deliver.redelivered,
-                exchange: deliver.exchange,
-                routing_key: deliver.routing_key,
+                exchange: deliver.exchange.to_string(),
+                routing_key: deliver.routing_key.to_string(),
                 body,
                 properties,
             },
@@ -55,8 +55,8 @@ impl Delivery {
             channel_id,
             delivery_tag: get_ok.delivery_tag,
             redelivered: get_ok.redelivered,
-            exchange: get_ok.exchange,
-            routing_key: get_ok.routing_key,
+            exchange: get_ok.exchange.to_string(),
+            routing_key: get_ok.routing_key.to_string(),
             body,
             properties,
         }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -9,6 +9,7 @@ pub type Result<T, E = Error> = result::Result<T, E>;
 /// Specific error cases returned by amiquip.
 #[derive(Snafu, Debug)]
 #[snafu(visibility(pub(crate)))]
+#[non_exhaustive]
 pub enum Error {
     /// URL parsing failed.
     #[snafu(display("could not parse url: {}", source))]
@@ -269,9 +270,6 @@ pub enum Error {
         channel_id: u16,
         consumer_tag: String,
     },
-
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 #[cfg(test)]

--- a/src/exchange.rs
+++ b/src/exchange.rs
@@ -68,8 +68,8 @@ impl ExchangeDeclareOptions {
     ) -> Declare {
         Declare {
             exchange: name.into(),
+            kind: type_.as_ref().into(),
             passive,
-            type_: type_.as_ref().to_string(),
             durable: self.durable,
             auto_delete: self.auto_delete,
             internal: self.internal,

--- a/src/exchange.rs
+++ b/src/exchange.rs
@@ -68,7 +68,7 @@ impl ExchangeDeclareOptions {
     ) -> Declare {
         Declare {
             ticket: 0,
-            exchange: name,
+            exchange: name.into(),
             passive,
             type_: type_.as_ref().to_string(),
             durable: self.durable,

--- a/src/exchange.rs
+++ b/src/exchange.rs
@@ -67,7 +67,6 @@ impl ExchangeDeclareOptions {
         nowait: bool,
     ) -> Declare {
         Declare {
-            ticket: 0,
             exchange: name.into(),
             passive,
             type_: type_.as_ref().to_string(),

--- a/src/frame_buffer.rs
+++ b/src/frame_buffer.rs
@@ -291,12 +291,12 @@ mod tests {
     fn callback_fail() {
         let mut c = Cursor::new(b"a\x04aa").chain(would_block());
 
-        // use __Nonexhaustive as "some non-parsing, non-I/O error"
+        // use MaformedFrame as placeholder for "some non-parsing, non-I/O error"
         let mut buf = make_buffer();
-        let res = buf.read_from(&mut c, |_| __NonexhaustiveSnafu.fail());
+        let res = buf.read_from(&mut c, |_| MalformedFrameSnafu.fail());
         assert!(res.is_err());
         match res.unwrap_err() {
-            Error::__Nonexhaustive => (),
+            Error::MalformedFrame => (),
             err => panic!("unexpected error {}", err),
         }
     }

--- a/src/frame_buffer.rs
+++ b/src/frame_buffer.rs
@@ -196,10 +196,12 @@ mod tests {
 
         let mut got = Vec::new();
         let mut buf = make_buffer();
-        let n = buf.read_from(&mut c, |f| {
-            got.push(f);
-            Ok(())
-        }).unwrap();
+        let n = buf
+            .read_from(&mut c, |f| {
+                got.push(f);
+                Ok(())
+            })
+            .unwrap();
 
         assert_eq!(n, 8);
         assert_eq!(got, vec![Vec::from(&frame0[..]), Vec::from(&frame1[..])]);
@@ -244,32 +246,32 @@ mod tests {
 
         let mut got = Vec::new();
         let mut buf = make_buffer();
-        let n = buf.read_from(&mut c, |f| {
-            got.push(f);
-            Ok(())
-        }).unwrap();
+        let n = buf
+            .read_from(&mut c, |f| {
+                got.push(f);
+                Ok(())
+            })
+            .unwrap();
         assert_eq!(n, 2);
         assert!(got.is_empty());
 
-        let n = buf.read_from(&mut c, |f| {
-            got.push(f);
-            Ok(())
-        }).unwrap();
+        let n = buf
+            .read_from(&mut c, |f| {
+                got.push(f);
+                Ok(())
+            })
+            .unwrap();
         assert_eq!(n, 5);
         assert_eq!(got, vec![b"a\x04aa".to_vec()]);
 
-        let n = buf.read_from(&mut c, |f| {
-            got.push(f);
-            Ok(())
-        }).unwrap();
+        let n = buf
+            .read_from(&mut c, |f| {
+                got.push(f);
+                Ok(())
+            })
+            .unwrap();
         assert_eq!(n, 3);
-        assert_eq!(
-            got,
-            vec![
-                b"a\x04aa".to_vec(),
-                b"b\x04bb".to_vec()
-            ]
-        );
+        assert_eq!(got, vec![b"a\x04aa".to_vec(), b"b\x04bb".to_vec()]);
     }
 
     #[test]

--- a/src/io_loop/channel_handle.rs
+++ b/src/io_loop/channel_handle.rs
@@ -12,6 +12,7 @@ use amq_protocol::protocol::channel::Open as ChannelOpen;
 use amq_protocol::protocol::channel::OpenOk as ChannelOpenOk;
 use amq_protocol::protocol::connection::Close as ConnectionClose;
 use amq_protocol::protocol::constants::REPLY_SUCCESS;
+use amq_protocol::types::ShortString;
 use crossbeam_channel::Sender as CrossbeamSender;
 use log::{debug, trace};
 use std::fmt::Debug;
@@ -50,7 +51,7 @@ impl Channel0Handle {
     pub(crate) fn close_connection(&mut self) -> Result<()> {
         let close = ConnectionClose {
             reply_code: u16::from(REPLY_SUCCESS),
-            reply_text: "goodbye".to_string(),
+            reply_text: "goodbye".into(),
             class_id: 0,
             method_id: 0,
         };
@@ -82,7 +83,7 @@ impl ChannelHandle {
     pub(crate) fn close(&mut self) -> Result<()> {
         let close = AmqpChannel::Close(ChannelClose {
             reply_code: 0,
-            reply_text: String::new(),
+            reply_text: ShortString::default(),
             class_id: 0,
             method_id: 0,
         });

--- a/src/io_loop/channel_handle.rs
+++ b/src/io_loop/channel_handle.rs
@@ -50,7 +50,7 @@ impl Channel0Handle {
 
     pub(crate) fn close_connection(&mut self) -> Result<()> {
         let close = ConnectionClose {
-            reply_code: u16::from(REPLY_SUCCESS),
+            reply_code: REPLY_SUCCESS,
             reply_text: "goodbye".into(),
             class_id: 0,
             method_id: 0,

--- a/src/io_loop/channel_handle.rs
+++ b/src/io_loop/channel_handle.rs
@@ -62,8 +62,7 @@ impl Channel0Handle {
         let mut handle = self.handle.allocate_channel(channel_id)?;
 
         debug!("opening channel {}", handle.channel_id());
-        let out_of_band = String::new();
-        let open = AmqpChannel::Open(ChannelOpen { out_of_band });
+        let open = AmqpChannel::Open(ChannelOpen {});
 
         let open_ok = handle.call::<_, ChannelOpenOk>(open)?;
         trace!("got open-ok: {:?}", open_ok);

--- a/src/io_loop/channel_slots.rs
+++ b/src/io_loop/channel_slots.rs
@@ -96,7 +96,10 @@ impl<T> ChannelSlots<T> {
 
         // At the end of our rope for simple channel allocation; fall back to finding
         // one that has been previously freed.
-        let channel_id = self.freed_channel_ids.pop().context(ExhaustedChannelIdsSnafu)?;
+        let channel_id = self
+            .freed_channel_ids
+            .pop()
+            .context(ExhaustedChannelIdsSnafu)?;
         match self.slots.entry(channel_id) {
             Entry::Occupied(_) => unreachable!("free channel id cannot be occupied"),
             Entry::Vacant(entry) => {

--- a/src/io_loop/connection_state.rs
+++ b/src/io_loop/connection_state.rs
@@ -157,7 +157,9 @@ impl ConnectionState {
             }
             // We never expect to see a protocl header (we send it to begin the connection)
             // or a heartbeat on a non-0 channel.
-            AMQPFrame::ProtocolHeader | AMQPFrame::Heartbeat(_) => return FrameUnexpectedSnafu.fail(),
+            AMQPFrame::ProtocolHeader(_) | AMQPFrame::Heartbeat(_) => {
+                return FrameUnexpectedSnafu.fail()
+            }
             // Server-initiated connection close.
             AMQPFrame::Method(0, AMQPClass::Connection(AmqpConnection::Close(close))) => {
                 inner.push_method(0, AmqpConnection::CloseOk(ConnectionCloseOk {}));

--- a/src/io_loop/connection_state.rs
+++ b/src/io_loop/connection_state.rs
@@ -40,7 +40,7 @@ fn slot_remove(inner: &mut Inner, channel_id: u16) -> Result<ChannelSlot> {
         .context(ReceivedFrameWithBogusChannelIdSnafu { channel_id })
 }
 
-fn slot_get(inner: &mut Inner, channel_id: u16) -> Result<&ChannelSlot> {
+fn slot_get(inner: &Inner, channel_id: u16) -> Result<&ChannelSlot> {
     inner
         .chan_slots
         .get(channel_id)

--- a/src/io_loop/connection_state.rs
+++ b/src/io_loop/connection_state.rs
@@ -397,13 +397,12 @@ impl ConnectionState {
                 if let Some(collected) = slot.collector.collect_header(*header)? {
                     match collected {
                         CollectorResult::Delivery((consumer_tag, delivery)) => {
-                            let tx =
-                                slot.consumers
-                                    .get(&consumer_tag)
-                                    .context(UnknownConsumerTagSnafu {
-                                        channel_id: n,
-                                        consumer_tag,
-                                    })?;
+                            let tx = slot.consumers.get(&consumer_tag).context(
+                                UnknownConsumerTagSnafu {
+                                    channel_id: n,
+                                    consumer_tag,
+                                },
+                            )?;
                             send(tx, ConsumerMessage::Delivery(delivery))?;
                         }
                         CollectorResult::Return(return_) => {
@@ -421,13 +420,12 @@ impl ConnectionState {
                 if let Some(collected) = slot.collector.collect_body(body)? {
                     match collected {
                         CollectorResult::Delivery((consumer_tag, delivery)) => {
-                            let tx =
-                                slot.consumers
-                                    .get(&consumer_tag)
-                                    .context(UnknownConsumerTagSnafu {
-                                        channel_id: n,
-                                        consumer_tag,
-                                    })?;
+                            let tx = slot.consumers.get(&consumer_tag).context(
+                                UnknownConsumerTagSnafu {
+                                    channel_id: n,
+                                    consumer_tag,
+                                },
+                            )?;
                             send(tx, ConsumerMessage::Delivery(delivery))?;
                         }
                         CollectorResult::Return(return_) => {

--- a/src/io_loop/connection_state.rs
+++ b/src/io_loop/connection_state.rs
@@ -128,7 +128,7 @@ impl ConnectionState {
         error!("{} - closing connection", reply_text);
         let close = ConnectionClose {
             reply_code: reply_code.get_id(),
-            reply_text,
+            reply_text: reply_text.into(),
             class_id: 0,
             method_id: 0,
         };
@@ -163,7 +163,7 @@ impl ConnectionState {
                 inner.push_method(0, AmqpConnection::CloseOk(ConnectionCloseOk {}));
                 inner.seal_writes();
                 let reply_code = close.reply_code;
-                let message = close.reply_text.clone();
+                let message = close.reply_text.to_string();
                 let make_err = || Error::ServerClosedConnection {
                     code: reply_code,
                     message: message.clone(),
@@ -198,7 +198,7 @@ impl ConnectionState {
             // Server is blocking publishes due to an alarm on its side (e.g., low mem)
             AMQPFrame::Method(0, AMQPClass::Connection(AmqpConnection::Blocked(blocked))) => {
                 warn!("server has blocked connection; reason = {}", blocked.reason);
-                let note = ConnectionBlockedNotification::Blocked(blocked.reason);
+                let note = ConnectionBlockedNotification::Blocked(blocked.reason.to_string());
                 try_send_blocked(ch0_slot, note);
             }
             // Server has unblocked publishes
@@ -224,7 +224,7 @@ impl ConnectionState {
                 let make_err = || Error::ServerClosedChannel {
                     channel_id: n,
                     code: close.reply_code,
-                    message: close.reply_text.clone(),
+                    message: close.reply_text.to_string(),
                 };
                 send(&slot.tx, Err(make_err()))?;
                 for (_, tx) in slot.consumers.drain() {
@@ -253,7 +253,7 @@ impl ConnectionState {
             }
             // Server ack for consume request.
             AMQPFrame::Method(n, AMQPClass::Basic(AmqpBasic::ConsumeOk(consume_ok))) => {
-                let consumer_tag = consume_ok.consumer_tag;
+                let consumer_tag = consume_ok.consumer_tag.to_string();
                 let slot = slot_get_mut(inner, n)?;
                 match slot.consumers.entry(consumer_tag.clone()) {
                     Entry::Occupied(_) => {
@@ -274,7 +274,7 @@ impl ConnectionState {
             AMQPFrame::Method(n, AMQPClass::Basic(AmqpBasic::Cancel(cancel))) => {
                 let consumer_tag = cancel.consumer_tag;
                 let slot = slot_get_mut(inner, n)?;
-                if let Some(tx) = slot.consumers.remove(&consumer_tag) {
+                if let Some(tx) = slot.consumers.remove(consumer_tag.as_str()) {
                     send(&tx, ConsumerMessage::ServerCancelled)?;
                 }
                 if !cancel.nowait {
@@ -284,7 +284,7 @@ impl ConnectionState {
             // Server ack for client-initiated consumer cancel.
             AMQPFrame::Method(n, AMQPClass::Basic(AmqpBasic::CancelOk(cancel_ok))) => {
                 let slot = slot_get_mut(inner, n)?;
-                let consumer = slot.consumers.remove(&cancel_ok.consumer_tag);
+                let consumer = slot.consumers.remove(cancel_ok.consumer_tag.as_str());
                 send(
                     &slot.tx,
                     Ok(ChannelMessage::Method(AMQPClass::Basic(

--- a/src/io_loop/content_collector.rs
+++ b/src/io_loop/content_collector.rs
@@ -235,20 +235,14 @@ impl<T: ContentType> State<T> {
                 let body_size = header.body_size as usize;
                 buf.append(&mut body);
                 match buf.len().cmp(&body_size) {
-                    Ordering::Equal => {
-                        Ok(Content::Done(T::new(
-                            channel_id,
-                            start,
-                            buf,
-                            header.properties,
-                        )))
-                    },
-                    Ordering::Less => {
-                        Ok(Content::NeedMore(State::Body(start, header, buf)))
-                    }
-                    _ => {
-                        FrameUnexpectedSnafu.fail()
-                    }
+                    Ordering::Equal => Ok(Content::Done(T::new(
+                        channel_id,
+                        start,
+                        buf,
+                        header.properties,
+                    ))),
+                    Ordering::Less => Ok(Content::NeedMore(State::Body(start, header, buf))),
+                    _ => FrameUnexpectedSnafu.fail(),
                 }
             }
             State::Start(_) => FrameUnexpectedSnafu.fail(),

--- a/src/io_loop/io_loop_handle.rs
+++ b/src/io_loop/io_loop_handle.rs
@@ -73,7 +73,9 @@ impl IoLoopHandle {
         self.send(IoLoopMessage::Send(buf))?;
         match self.recv()? {
             ChannelMessage::GetOk(get) => Ok(*get),
-            ChannelMessage::Method(_) | ChannelMessage::ConsumeOk(_, _) => FrameUnexpectedSnafu.fail(),
+            ChannelMessage::Method(_) | ChannelMessage::ConsumeOk(_, _) => {
+                FrameUnexpectedSnafu.fail()
+            }
         }
     }
 
@@ -106,7 +108,9 @@ impl IoLoopHandle {
         self.send(message)?;
         match self.recv()? {
             ChannelMessage::Method(method) => T::try_from(method),
-            ChannelMessage::ConsumeOk(_, _) | ChannelMessage::GetOk(_) => FrameUnexpectedSnafu.fail(),
+            ChannelMessage::ConsumeOk(_, _) | ChannelMessage::GetOk(_) => {
+                FrameUnexpectedSnafu.fail()
+            }
         }
     }
 

--- a/src/io_loop/io_loop_handle.rs
+++ b/src/io_loop/io_loop_handle.rs
@@ -107,7 +107,7 @@ impl IoLoopHandle {
     fn call_message<T: TryFromAmqpClass>(&mut self, message: IoLoopMessage) -> Result<T> {
         self.send(message)?;
         match self.recv()? {
-            ChannelMessage::Method(method) => T::try_from(method),
+            ChannelMessage::Method(method) => T::try_from_class(method),
             ChannelMessage::ConsumeOk(_, _) | ChannelMessage::GetOk(_) => {
                 FrameUnexpectedSnafu.fail()
             }

--- a/src/io_loop/mod.rs
+++ b/src/io_loop/mod.rs
@@ -349,7 +349,7 @@ impl IoLoop {
             HandshakeState::Done(tune_ok, server_properties) => Ok((tune_ok, server_properties)),
             HandshakeState::ServerClosing(close) => ServerClosedConnectionSnafu {
                 code: close.reply_code,
-                message: close.reply_text,
+                message: close.reply_text.to_string(),
             }
             .fail(),
         }
@@ -416,7 +416,7 @@ impl IoLoop {
             ConnectionState::Steady(_) => unreachable!(),
             ConnectionState::ServerClosing(close) => ServerClosedConnectionSnafu {
                 code: close.reply_code,
-                message: close.reply_text,
+                message: close.reply_text.to_string(),
             }
             .fail(),
             ConnectionState::ClientException => ClientExceptionSnafu.fail(),

--- a/src/io_loop/mod.rs
+++ b/src/io_loop/mod.rs
@@ -721,7 +721,7 @@ impl Inner {
                         // enqueuing up a heartbeat frame
                         if self.outbuf.is_empty() {
                             debug!("sending heartbeat");
-                            self.outbuf.push_heartbeat();
+                            self.outbuf.push_heartbeat(0);
                         } else {
                             warn!("tx heartbeat fired, but already have queued data to write - possible socket problem");
                         }

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -15,8 +15,8 @@ use amq_protocol::protocol::queue::{Declare, Delete};
 /// # use amiquip::{AmqpValue, QueueDeclareOptions, FieldTable};
 /// let mut arguments = FieldTable::new();
 /// arguments.insert(
-///     "x-queue-type".to_string(),
-///     AmqpValue::LongString("quorum".to_string()),
+///     "x-queue-type".into(),
+///     AmqpValue::LongString("quorum".into()),
 /// );
 /// let options = QueueDeclareOptions {
 ///     arguments,

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -13,7 +13,7 @@ use amq_protocol::protocol::queue::{Declare, Delete};
 ///
 /// ```rust
 /// # use amiquip::{AmqpValue, QueueDeclareOptions, FieldTable};
-/// let mut arguments = FieldTable::new();
+/// let mut arguments = FieldTable::default();
 /// arguments.insert(
 ///     "x-queue-type".into(),
 ///     AmqpValue::LongString("quorum".into()),

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -48,7 +48,6 @@ pub struct QueueDeclareOptions {
 impl QueueDeclareOptions {
     pub(crate) fn into_declare(self, queue: String, passive: bool, nowait: bool) -> Declare {
         Declare {
-            ticket: 0,
             queue: queue.into(),
             passive,
             durable: self.durable,
@@ -76,7 +75,6 @@ pub struct QueueDeleteOptions {
 impl QueueDeleteOptions {
     pub(crate) fn into_delete(self, queue: String, nowait: bool) -> Delete {
         Delete {
-            ticket: 0,
             queue: queue.into(),
             if_unused: self.if_unused,
             if_empty: self.if_empty,

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -49,7 +49,7 @@ impl QueueDeclareOptions {
     pub(crate) fn into_declare(self, queue: String, passive: bool, nowait: bool) -> Declare {
         Declare {
             ticket: 0,
-            queue,
+            queue: queue.into(),
             passive,
             durable: self.durable,
             exclusive: self.exclusive,
@@ -77,7 +77,7 @@ impl QueueDeleteOptions {
     pub(crate) fn into_delete(self, queue: String, nowait: bool) -> Delete {
         Delete {
             ticket: 0,
-            queue,
+            queue: queue.into(),
             if_unused: self.if_unused,
             if_empty: self.if_empty,
             nowait,

--- a/src/return_.rs
+++ b/src/return_.rs
@@ -32,9 +32,9 @@ impl Return {
     pub(crate) fn new(ret: AmqpReturn, content: Vec<u8>, properties: AmqpProperties) -> Return {
         Return {
             reply_code: ret.reply_code,
-            reply_text: ret.reply_text,
-            exchange: ret.exchange,
-            routing_key: ret.routing_key,
+            reply_text: ret.reply_text.to_string(),
+            exchange: ret.exchange.to_string(),
+            routing_key: ret.routing_key.to_string(),
             content,
             properties,
         }

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -1,7 +1,5 @@
 use crate::errors::*;
-use amq_protocol::frame::generation::{
-    gen_content_body_frame, gen_content_header_frame, gen_heartbeat_frame, gen_method_frame,
-};
+use amq_protocol::frame::AMQPContentHeader;
 use amq_protocol::frame::AMQPFrame;
 use amq_protocol::protocol::basic::AMQPMethod as AmqpBasic;
 use amq_protocol::protocol::basic::AMQPProperties;
@@ -11,11 +9,9 @@ use amq_protocol::protocol::connection::AMQPMethod as AmqpConnection;
 use amq_protocol::protocol::exchange::AMQPMethod as AmqpExchange;
 use amq_protocol::protocol::queue::AMQPMethod as AmqpQueue;
 use amq_protocol::protocol::AMQPClass;
-use cookie_factory::GenError;
 use std::ops::{Index, RangeFrom};
-use std::result::Result as StdResult;
 
-pub trait TryFromAmqpClass: Sized {
+pub(crate) trait TryFromAmqpClass: Sized {
     fn try_from(class: AMQPClass) -> Result<Self>;
 }
 
@@ -167,7 +163,7 @@ impl<T: TryFromAmqpClass> TryFromAmqpFrame for T {
     }
 }
 
-pub trait IntoAmqpClass {
+pub(crate) trait IntoAmqpClass {
     fn into_class(self) -> AMQPClass;
 }
 
@@ -211,7 +207,7 @@ impl IntoAmqpClass for AmqpExchange {
 pub(crate) struct OutputBuffer(Vec<u8>);
 
 impl OutputBuffer {
-    pub fn with_protocol_header() -> OutputBuffer {
+    pub(crate) fn with_protocol_header() -> OutputBuffer {
         OutputBuffer(b"AMQP\x00\x00\x09\x01".to_vec())
     }
 
@@ -225,21 +221,20 @@ impl OutputBuffer {
         buf
     }
 
-    pub fn push_heartbeat(&mut self) {
+    pub(crate) fn push_heartbeat(&mut self, channel_id: u16) {
         // serializing heartbeat cannot fail; safe to unwrap.
-        serialize(&mut self.0, |buf, pos| gen_heartbeat_frame((buf, pos)))
+        let frame = AMQPFrame::Heartbeat(channel_id);
+        self.append_frame(frame);
     }
 
     // This can only fail if there is a bug in the serialization library; it is probably
     // safe to unwrap, but little cost to return a Result instead.
-    pub fn push_method<M>(&mut self, channel_id: u16, method: M)
+    pub(crate) fn push_method<M>(&mut self, channel_id: u16, method: M)
     where
         M: IntoAmqpClass,
     {
-        let class = method.into_class();
-        serialize(&mut self.0, |buf, pos| {
-            gen_method_frame((buf, pos), channel_id, &class)
-        })
+        let frame = AMQPFrame::Method(channel_id, method.into_class());
+        self.append_frame(frame);
     }
 
     pub(crate) fn push_content_header(
@@ -249,40 +244,48 @@ impl OutputBuffer {
         length: usize,
         properties: &AMQPProperties,
     ) {
-        let length = length as u64;
-        serialize(&mut self.0, |buf, pos| {
-            gen_content_header_frame((buf, pos), channel_id, class_id, length, properties)
-        })
+        let header = Box::new(AMQPContentHeader {
+            class_id,
+            body_size: length as u64,
+            properties: properties.to_owned(),
+        });
+        let frame = AMQPFrame::Header(channel_id, class_id, header);
+        self.append_frame(frame);
     }
 
     pub(crate) fn push_content_body(&mut self, channel_id: u16, content: &[u8]) {
-        serialize(&mut self.0, |buf, pos| {
-            gen_content_body_frame((buf, pos), channel_id, content)
-        })
+        let frame = AMQPFrame::Body(channel_id, content.into());
+        self.append_frame(frame);
+    }
+
+    fn append_frame(&mut self, frame: AMQPFrame) {
+        let serialize_fn = amq_protocol::frame::gen_frame(&frame);
+        let (mut buf, _) = serialize_fn(Vec::<u8>::new().into()).unwrap().into_inner();
+        self.0.append(&mut buf);
     }
 
     #[inline]
-    pub fn is_empty(&self) -> bool {
+    pub(crate) fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
 
     #[inline]
-    pub fn len(&self) -> usize {
+    pub(crate) fn len(&self) -> usize {
         self.0.len()
     }
 
     #[inline]
-    pub fn clear(&mut self) {
+    pub(crate) fn clear(&mut self) {
         self.0.clear()
     }
 
     #[inline]
-    pub fn drain_written(&mut self, n: usize) {
+    pub(crate) fn drain_written(&mut self, n: usize) {
         self.0.drain(0..n);
     }
 
     #[inline]
-    pub fn append(&mut self, mut other: OutputBuffer) {
+    pub(crate) fn append(&mut self, mut other: OutputBuffer) {
         self.0.append(&mut other.0)
     }
 }
@@ -317,9 +320,9 @@ impl SealableOutputBuffer {
     }
 
     #[inline]
-    pub(super) fn push_heartbeat(&mut self) {
+    pub(super) fn push_heartbeat(&mut self, channel_id: u16) {
         if !self.sealed {
-            self.buf.push_heartbeat();
+            self.buf.push_heartbeat(channel_id);
         }
     }
 
@@ -370,21 +373,6 @@ impl Index<RangeFrom<usize>> for SealableOutputBuffer {
     }
 }
 
-fn serialize<F: Fn(&mut [u8], usize) -> StdResult<(&mut [u8], usize), GenError>>(
-    buf: &mut Vec<u8>,
-    f: F,
-) {
-    let pos = buf.len();
-    loop {
-        let resize_to = match f(buf, pos) {
-            Ok(_) => return,
-            Err(GenError::BufferTooSmall(n)) => n,
-            Err(err) => unreachable!("impossible serialization error: {:?}", err),
-        };
-        buf.resize(resize_to, 0);
-    }
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
@@ -393,8 +381,8 @@ mod test {
     #[test]
     fn test_heartbeat() {
         let mut buf = OutputBuffer::empty();
-        buf.push_heartbeat();
-        let expected = [8, 0, 0, 0, 0, 0, 0, 206];
+        buf.push_heartbeat(3);
+        let expected = [8, 0, 3, 0, 0, 0, 0, 206];
         assert_eq!(buf.0, &expected);
     }
 
@@ -413,7 +401,8 @@ mod test {
     fn test_content_header() {
         let mut buf = OutputBuffer::empty();
         let properties = AMQPProperties::default();
-        buf.push_content_header(3, Publish::get_class_id(), 0, &properties);
+        let class_id = Publish::default().get_amqp_class_id();
+        buf.push_content_header(3, class_id, 0, &properties);
         let expected = [
             2, 0, 3, 0, 0, 0, 14, 0, 60, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 206,
         ];
@@ -435,7 +424,8 @@ mod test {
         let mut buf = OutputBuffer::empty();
         let properties = AMQPProperties::default();
         let body = "test body";
-        buf.push_content_header(3, Publish::get_class_id(), body.len(), &properties);
+        let class_id = Publish::default().get_amqp_class_id();
+        buf.push_content_header(3, class_id, body.len(), &properties);
         buf.push_content_body(3, body.as_bytes());
         let expected = [
             2, 0, 3, 0, 0, 0, 14, 0, 60, 0, 0, 0, 0, 0, 0, 0, 0, 0, 9, 0, 0, 206, 3, 0, 3, 0, 0, 0,

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -12,13 +12,13 @@ use amq_protocol::protocol::AMQPClass;
 use std::ops::{Index, RangeFrom};
 
 pub(crate) trait TryFromAmqpClass: Sized {
-    fn try_from(class: AMQPClass) -> Result<Self>;
+    fn try_from_class(class: AMQPClass) -> Result<Self>;
 }
 
 macro_rules! impl_try_from_class {
     ($type:ty, $class:path, $method:path) => {
         impl TryFromAmqpClass for $type {
-            fn try_from(class: AMQPClass) -> Result<Self> {
+            fn try_from_class(class: AMQPClass) -> Result<Self> {
                 match class {
                     $class($method(val)) => Ok(val),
                     _ => FrameUnexpectedSnafu.fail(),
@@ -145,15 +145,15 @@ impl_try_from_class!(
 );
 
 pub(crate) trait TryFromAmqpFrame: Sized {
-    fn try_from(channel_id: u16, frame: AMQPFrame) -> Result<Self>;
+    fn try_from_frame(channel_id: u16, frame: AMQPFrame) -> Result<Self>;
 }
 
 impl<T: TryFromAmqpClass> TryFromAmqpFrame for T {
-    fn try_from(expected_id: u16, frame: AMQPFrame) -> Result<Self> {
+    fn try_from_frame(expected_id: u16, frame: AMQPFrame) -> Result<Self> {
         match frame {
             AMQPFrame::Method(channel_id, method) => {
                 if expected_id == channel_id {
-                    Self::try_from(method)
+                    Self::try_from_class(method)
                 } else {
                     FrameUnexpectedSnafu.fail()
                 }


### PR DESCRIPTION
Hi there! I also use this crate in a codebase I maintain. >_>

Like the filer of #45, I'd also like to get ahead of the future incompatibility warnings that started ~on or about rustc 1.71.0~ with rustc 1.69.0. Those are fixed in the first series of commits (up to bb41f94) by bumping the version of the `amq-protocol` crate that was pulling in the problematic `nom` dependency.

The second series does a general version bump across most of the other dependencies and a few other bits of hygiene intended to push the next time this is needed as far into the future as possible (given that you mentioned the crate is no longer maintained actively in #46).

They're separated to make a clear boundary between what's necessary and what's not, but I doubt there's anything controversial in the extra bits.

Notes: 
- The `mio` dependency remains at 0.6 despite 0.8 being available. This is because `mio-extras` appears to have chosen to stay at 0.6, and the [jump to 0.7](https://tokio.rs/blog/2019-12-mio-v0.7-alpha.1) was fairly significant. `mio-extras` recommends `mio-misc` as an 0.7-supporting alternative, but the translation between the two isn't a quick one-to-one like most of the other changes in this PR. I expect this will be the next source of maintenance issues. A partial migration is [here](https://github.com/vkkoskie/amiquip/tree/mio-partial).
- `amq-protocol` now makes a distinction between the short and long string types from the spec. However, conversions are both infallible `From<String>` and the bounds are [definitely not enforced](https://docs.rs/amq-protocol-types/7.1.2/src/amq_protocol_types/generation.rs.html#130). Given that the `ShortString` type is marked as deprecated, I opted to simply allow these conversions to take place as written, and didn't attempt to add new bounds checks (which would also address #43).
- Though the PR indicates 1.72.0, rustc 1.73.0-beta was actually used for confirmation. The bump to the 2021 Edition makes rustc 1.56.0 a plausible minimum, but I didn't confirm that.
- Only two backward incompatible changes to the public API were needed. Both are mentioned in the Changelog.

Closes #45